### PR TITLE
chore: ignore media folder except .gitkeep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,5 @@ next-env.d.ts
 
 .env
 
-/media
+/media/*
+!/media/.gitkeep


### PR DESCRIPTION
## What
+ Ignore the contents of the `media` folder, except for `.gitkeep`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated repository settings for managing media content, ensuring that general files are excluded from version control while preserving key assets needed for folder structure integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->