### PR TITLE
fix: only view seat map, hide calendar popover and schedule section

### DIFF
--- a/src/app/(frontend)/events/[eventId]/page.tsx
+++ b/src/app/(frontend)/events/[eventId]/page.tsx
@@ -4,7 +4,7 @@ import config from '@/payload.config'
 import { notFound } from 'next/navigation'
 import PageClient from './page.client'
 import EventBanner from '@/components/EventDetail/EventBanner'
-import Schedule from '@/components/EventDetail/Schedule'
+// import Schedule from '@/components/EventDetail/Schedule'
 import TermCondition from '@/components/EventDetail/TermCondition'
 import SeatReservationClient from '@/components/EventDetail/SeatReservation/Component.client'
 import FeaturedPerformers from '@/components/EventDetail/FeaturedPerformers/Component'
@@ -63,7 +63,6 @@ const EventDetailPage = async (props: {
           <EventBanner event={eventDetail} />
           {isUpcoming && <UpcomingSaleBanner />}
 
-
           <DetailDescriptionClient event={eventDetail} />
           {isOpenForSales && (
             <SeatReservationClient
@@ -75,7 +74,7 @@ const EventDetailPage = async (props: {
           <FeaturedPerformers />
           {!isUpcoming && (
             <>
-              {!!eventDetail.schedules?.length && <Schedule schedules={eventDetail.schedules} />}
+              {/* {!!esventDetail.schedules?.length && <Schedule schedules={eventDetail.schedules} />} */}
               {eventDetail.eventTermsAndConditions && (
                 <TermCondition termCondition={eventDetail.eventTermsAndConditions} />
               )}

--- a/src/components/EventDetail/SeatReservation/DateSelector.tsx
+++ b/src/components/EventDetail/SeatReservation/DateSelector.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { format } from 'date-fns'
-import { Calendar } from '@/components/ui/calendar'
+// import { Calendar } from '@/components/ui/calendar'
 import { Button } from '@/components/ui/button'
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
-import { cn } from '@/lib/utils'
-import { CalendarIcon } from 'lucide-react'
+// import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+// import { cn } from '@/lib/utils'
+// import { CalendarIcon } from 'lucide-react'
 import { Event } from '@/payload-types'
 
 interface DateSelectorProps {
@@ -15,21 +15,21 @@ interface DateSelectorProps {
 
 const DateSelector: React.FC<DateSelectorProps> = ({ schedules, selectedDate, onDateSelect }) => {
   // Convert schedule dates to Date objects for the calendar
-  const availableDates = schedules
-    .filter((schedule) => schedule.date)
-    .map((schedule) => new Date(schedule.date as string))
+  // const availableDates = schedules
+  //   .filter((schedule) => schedule.date)
+  //   .map((schedule) => new Date(schedule.date as string))
 
-  const isDateAvailable = (date: Date) => {
-    return availableDates.some(
-      (availableDate) => availableDate.toDateString() === date.toDateString(),
-    )
-  }
+  // const isDateAvailable = (date: Date) => {
+  //   return availableDates.some(
+  //     (availableDate) => availableDate.toDateString() === date.toDateString(),
+  //   )
+  // }
 
   return (
     <div className="w-full mb-8">
       <h3 className="text-xl font-bold mb-4">Chọn ngày bạn muốn tham dự</h3>
       <div className="flex flex-col sm:flex-row items-center gap-4 justify-center">
-        <Popover>
+        {/* <Popover>
           <PopoverTrigger asChild>
             <Button
               variant="outline"
@@ -52,7 +52,7 @@ const DateSelector: React.FC<DateSelectorProps> = ({ schedules, selectedDate, on
               className={cn('p-3 pointer-events-auto')}
             />
           </PopoverContent>
-        </Popover>
+        </Popover> */}
 
         <div className="flex flex-wrap gap-2 justify-center">
           {schedules.map((schedule) => (

--- a/src/components/EventDetail/SeatReservation/SeatToolkit.tsx
+++ b/src/components/EventDetail/SeatReservation/SeatToolkit.tsx
@@ -1,12 +1,19 @@
 import React, { useEffect, useState } from 'react'
 import '@mezh-hq/react-seat-toolkit/styles'
-import SeatToolkit, { SeatStatus } from '@mezh-hq/react-seat-toolkit'
+import SeatToolkit from '@mezh-hq/react-seat-toolkit'
 import { Armchair, Loader2 } from 'lucide-react'
 import seatsJson from '@/components/EventDetail/data/seat-maps/seats.json'
 import texts from '@/components/EventDetail/data/seat-maps/texts.json'
 import { categories } from '../data/seat-maps/categories'
-import { Dialog, DialogContent, DialogTitle, DialogHeader, DialogFooter, DialogClose } from '@/components/ui/dialog'
-import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogHeader,
+  DialogFooter,
+  DialogClose,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
 
 type SeatItem = {
   id: string
@@ -19,7 +26,7 @@ type SeatItem = {
 }
 
 const SeatMapToolkit = ({
-  onSelectSeat,
+  // onSelectSeat,
   unavailableSeats,
 }: {
   onSelectSeat: (seat: any) => void
@@ -45,53 +52,53 @@ const SeatMapToolkit = ({
     }
   }, [unavailableSeats])
 
-  const handleSeatClick = (seat: any) => {
-    const seatRowChar = seat.label[0];
-    const seatNumber = parseInt(seat.id.split('-')[1]);
+  // const handleSeatClick = (seat: any) => {
+  //   const seatRowChar = seat.label[0];
+  //   const seatNumber = parseInt(seat.id.split('-')[1]);
 
-    const selectedSeatNumbersInRow = seats
-    .filter((s) => s.status === 'Reserved' && s.label?.[0] === seatRowChar)
-    .map((s) => parseInt(s.id.split('-')[1] ?? '0', 10));
+  //   const selectedSeatNumbersInRow = seats
+  //   .filter((s) => s.status === 'Reserved' && s.label?.[0] === seatRowChar)
+  //   .map((s) => parseInt(s.id.split('-')[1] ?? '0', 10));
 
-    const isSelectedSeatAdjacentToAnySeatInSeatsOnRow = selectedSeatNumbersInRow.length === 0 ||
-    selectedSeatNumbersInRow.some((num) => Math.abs(num - seatNumber) === 1);
-    if (
-      seat.status === SeatStatus.Available &&
-      !isSelectedSeatAdjacentToAnySeatInSeatsOnRow
-    ) {
-      setShowModal(true)
-      return
-    }
+  //   const isSelectedSeatAdjacentToAnySeatInSeatsOnRow = selectedSeatNumbersInRow.length === 0 ||
+  //   selectedSeatNumbersInRow.some((num) => Math.abs(num - seatNumber) === 1);
+  //   if (
+  //     seat.status === SeatStatus.Available &&
+  //     !isSelectedSeatAdjacentToAnySeatInSeatsOnRow
+  //   ) {
+  //     setShowModal(true)
+  //     return
+  //   }
 
-    if (seat.status !== SeatStatus.Unavailable && seat.status !== SeatStatus.Locked ) {
-      onSelectSeat(seat)
-      setSeats((prevSeats) => {
-        return prevSeats.map((s) => {
-          const seatNewStatus = () =>{
-            if (s.status === SeatStatus.Reserved) {
-              return SeatStatus.Available
-            }
-            else if (isSelectedSeatAdjacentToAnySeatInSeatsOnRow) {
-              return SeatStatus.Reserved
-            } else {
-              return SeatStatus.Available
-            }
-          }
-          if (
-            s.id === seat.id &&
-            s.status !== SeatStatus.Unavailable &&
-            s.status !== SeatStatus.Locked
-          ) {
-            return {
-              ...s,
-              status: seatNewStatus(),
-            }
-          }
-          return s
-        })
-      })
-    }
-  }
+  //   if (seat.status !== SeatStatus.Unavailable && seat.status !== SeatStatus.Locked ) {
+  //     onSelectSeat(seat)
+  //     setSeats((prevSeats) => {
+  //       return prevSeats.map((s) => {
+  //         const seatNewStatus = () =>{
+  //           if (s.status === SeatStatus.Reserved) {
+  //             return SeatStatus.Available
+  //           }
+  //           else if (isSelectedSeatAdjacentToAnySeatInSeatsOnRow) {
+  //             return SeatStatus.Reserved
+  //           } else {
+  //             return SeatStatus.Available
+  //           }
+  //         }
+  //         if (
+  //           s.id === seat.id &&
+  //           s.status !== SeatStatus.Unavailable &&
+  //           s.status !== SeatStatus.Locked
+  //         ) {
+  //           return {
+  //             ...s,
+  //             status: seatNewStatus(),
+  //           }
+  //         }
+  //         return s
+  //       })
+  //     })
+  //   }
+  // }
 
   return (
     <div className="relative">
@@ -103,9 +110,22 @@ const SeatMapToolkit = ({
       )}
       <SeatToolkit
         mode={'user'}
-        events={{
-          onSeatClick: handleSeatClick,
+        styles={{
+          elements: {
+            seat: {
+              base: {
+                properties: {
+                  cursor: 'not-allowed',
+                },
+              },
+            },
+          },
         }}
+        events={
+          {
+            // onSeatClick: handleSeatClick,
+          }
+        }
         data={{
           name: 'Categorized Example',
           categories: categories,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the event details view so schedule information is no longer displayed for certain events.
  - Streamlined date selection by removing the interactive calendar while retaining simple selectable date options.
  - Disabled interactive seat selection, with seats now indicating they cannot be selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->