### PR TITLE
fix: set default zalo payment

### DIFF
--- a/src/components/EventDetail/SeatReservation/ConfirmOrderWithTicketClassModal.tsx
+++ b/src/components/EventDetail/SeatReservation/ConfirmOrderWithTicketClassModal.tsx
@@ -60,7 +60,7 @@ const ConfirmOrderWithTicketClassModal = ({
   ]
 
   const [selectedPaymentMethod, setSelectedPaymentMethod] = useState<string>(
-    PAYMENT_METHODS.BANK_TRANSFER,
+    PAYMENT_METHODS.ZALOPAY,
   )
 
   const {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the default payment option in the order confirmation step so that ZALOPAY is pre-selected, enhancing the checkout experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->