### PR TITLE
fix: set vi as default language

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,6 @@ VIET_QR_BANK_NAME="Ngân hàng thương mại cổ phần Ngoại thương Việ
 VIET_QR_ACQ_ID=[Bin Card] # https://developers.momo.vn/v3/docs/payment/api/result-handling/bankcode/
 VIET_QR_TEMPLATE=compact
 VIET_QR_ENCRYPT_KEY=
+
+# DEFAULT LOCALE WEB
+NEXT_PUBLIC_DEFAULT_FALLBACK_LOCALE='vi'

--- a/src/components/Home/components/Sponsors.tsx
+++ b/src/components/Home/components/Sponsors.tsx
@@ -1,3 +1,6 @@
+'use client'
+
+import { useTranslate } from '@/providers/I18n/client'
 import { Partner } from '@/types/Partner'
 import React, { useRef, useEffect, useState } from 'react'
 
@@ -6,6 +9,7 @@ interface SponsorsProps {
 }
 
 const Sponsors: React.FC<SponsorsProps> = ({ partners = [] }) => {
+  const { t } = useTranslate()
   const sectionRef = useRef<HTMLDivElement>(null)
   const [currentPage, setCurrentPage] = useState(0)
   const sponsorsPerPage = 5
@@ -48,7 +52,7 @@ const Sponsors: React.FC<SponsorsProps> = ({ partners = [] }) => {
       <div className="container mx-auto px-6 md:px-10">
         <div className="text-center mb-12">
           <h2 className="text-4xl font-extrabold bg-gradient-to-r from-gray-700 to-gray-950 bg-clip-text text-transparent">
-            Nhà Tài Trợ Và Đối Tác
+            {t('home.sponsorsAndPartners')}
           </h2>
           <div className="w-24 h-1 bg-gradient-to-r from-gray-950 to-gray-700 mx-auto mt-4 rounded-full" />
         </div>

--- a/src/components/LanguageSwitcher/index.tsx
+++ b/src/components/LanguageSwitcher/index.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { cn } from '@/lib/utils'
 import { getCookie, setCookie } from '@/utilities/clientCookies'
+import { DEFAULT_FALLBACK_LOCALE } from '@/config/app'
 
 type Language = {
   code: string
@@ -26,7 +27,7 @@ interface LanguageSwitcherProps {
 }
 
 const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({ className }) => {
-  const locale = getCookie('next-locale') || 'vi'
+  const locale = getCookie('next-locale') || DEFAULT_FALLBACK_LOCALE
 
   const currentLanguage = useMemo(() => {
     return languages.find((l) => l.code === (locale as string)) || (languages[0] as Language)

--- a/src/components/LanguageSwitcher/index.tsx
+++ b/src/components/LanguageSwitcher/index.tsx
@@ -26,7 +26,7 @@ interface LanguageSwitcherProps {
 }
 
 const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({ className }) => {
-  const locale = getCookie('next-locale') || 'en'
+  const locale = getCookie('next-locale') || 'vi'
 
   const currentLanguage = useMemo(() => {
     return languages.find((l) => l.code === (locale as string)) || (languages[0] as Language)

--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -1,1 +1,3 @@
 export const APP_BASE_URL = process.env.APP_BASE_URL || 'http://localhost:3000'
+export const DEFAULT_FALLBACK_LOCALE =
+  (process.env.NEXT_PUBLIC_DEFAULT_FALLBACK_LOCALE as 'vi' | 'en') || 'vi'

--- a/src/payload-config/i18n/index.ts
+++ b/src/payload-config/i18n/index.ts
@@ -9,7 +9,7 @@ export const i18n: Config['i18n'] = {
     en: extraEnLanguage,
     vi: extraViLanguage,
   },
-  fallbackLanguage: 'en',
+  fallbackLanguage: 'vi',
   supportedLanguages: {
     en: en as any,
     vi: vi as any,

--- a/src/payload-config/i18n/index.ts
+++ b/src/payload-config/i18n/index.ts
@@ -3,13 +3,14 @@ import { en } from '@payloadcms/translations/languages/en'
 import { vi } from '@payloadcms/translations/languages/vi'
 import extraEnLanguage from './locales/en.json'
 import extraViLanguage from './locales/vi.json'
+import { DEFAULT_FALLBACK_LOCALE } from '@/config/app'
 
 export const i18n: Config['i18n'] = {
   translations: {
     en: extraEnLanguage,
     vi: extraViLanguage,
   },
-  fallbackLanguage: 'vi',
+  fallbackLanguage: DEFAULT_FALLBACK_LOCALE,
   supportedLanguages: {
     en: en as any,
     vi: vi as any,

--- a/src/payload-config/localization/index.ts
+++ b/src/payload-config/localization/index.ts
@@ -1,7 +1,8 @@
+import { DEFAULT_FALLBACK_LOCALE } from '@/config/app'
 import { Config } from 'payload'
 
 export const localization: Config['localization'] = {
-  defaultLocale: 'en',
+  defaultLocale: DEFAULT_FALLBACK_LOCALE,
   fallback: true,
   locales: [
     {

--- a/src/providers/I18n/client/index.ts
+++ b/src/providers/I18n/client/index.ts
@@ -2,9 +2,10 @@ import { getCookie } from '@/utilities/clientCookies'
 import { i18n as i18nPayloadConfig } from '@/payload-config/i18n'
 import { translate } from '../utils'
 import { useCallback } from 'react'
+import { DEFAULT_FALLBACK_LOCALE } from '@/config/app'
 
 export const useTranslate = () => {
-  const locale = getCookie('next-locale') || 'en'
+  const locale = getCookie('next-locale') || DEFAULT_FALLBACK_LOCALE
 
   const t = useCallback(
     (key: string) => {

--- a/src/providers/I18n/server/index.ts
+++ b/src/providers/I18n/server/index.ts
@@ -3,7 +3,7 @@ import { i18n as i18nPayloadConfig } from '@/payload-config/i18n'
 import { translate } from '../utils'
 
 const COOKIE_NAME = 'next-locale'
-const DEFAULT_LOCALE = i18nPayloadConfig?.fallbackLanguage || 'en'
+const DEFAULT_LOCALE = i18nPayloadConfig?.fallbackLanguage || 'vi'
 
 export async function getLocale() {
   const headersList = await headers()

--- a/src/providers/I18n/server/index.ts
+++ b/src/providers/I18n/server/index.ts
@@ -1,9 +1,10 @@
 import { cookies, headers } from 'next/headers'
 import { i18n as i18nPayloadConfig } from '@/payload-config/i18n'
 import { translate } from '../utils'
+import { DEFAULT_FALLBACK_LOCALE } from '@/config/app'
 
 const COOKIE_NAME = 'next-locale'
-const DEFAULT_LOCALE = i18nPayloadConfig?.fallbackLanguage || 'vi'
+const DEFAULT_LOCALE = i18nPayloadConfig?.fallbackLanguage || DEFAULT_FALLBACK_LOCALE
 
 export async function getLocale() {
   const headersList = await headers()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**  
  - Enhanced the sponsor section with dynamic translation support, ensuring content is displayed in the appropriate language.  

- **Improvements**  
  - Updated default language settings across the platform to prioritize Vietnamese over English, providing a more localized experience by default.  
  - Introduced a new environment variable for setting the default fallback locale, improving configuration flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->