### PR TITLE
fix: reduce schedule job limit

### DIFF
--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -155,7 +155,7 @@ export default buildConfig({
     autoRun: [
       {
         cron: '*/5 * * * *', // Runs every 5 minutes
-        limit: 2, // limit jobs to process each run
+        limit: 1, // limit jobs to process each run
         queue: 'updatePaymentStatus', // name of the queue
       },
     ],


### PR DESCRIPTION
##What
+ The limit of jobs processed by the schedule job has been reduced from 2 to 1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Reduced the maximum number of jobs processed per run for the payment status update queue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->