### PR TITLE
fix: Increase revalidate time for cached data to 24 hours

### DIFF
--- a/src/app/(frontend)/events/[eventId]/actions/index.ts
+++ b/src/app/(frontend)/events/[eventId]/actions/index.ts
@@ -42,6 +42,7 @@ export const getEventCached = ({ slug, locale }: { slug: string; locale?: Suppor
     [`${locale || DEFAULT_FALLBACK_LOCALE}-${slug}`],
     {
       tags: [`event-detail:${slug}`],
+      revalidate: 86400, // 24 hours
     },
   )
 
@@ -54,4 +55,5 @@ export const getPerformersByEventCached = ({
 }) =>
   unstable_cache(async () => fetchPerformers({ locale }), [locale || DEFAULT_FALLBACK_LOCALE], {
     tags: [`event-performers`],
+    revalidate: 86400, // 24 hours
   })

--- a/src/app/(frontend)/events/[eventId]/page.tsx
+++ b/src/app/(frontend)/events/[eventId]/page.tsx
@@ -19,7 +19,7 @@ import { cookies } from 'next/headers'
 import { getLocale } from '@/providers/I18n/server'
 
 // export const dynamic = 'force-dynamic'
-export const revalidate = 3600
+export const revalidate = 86400 // 24 hours
 export const dynamicParams = true
 
 const EventDetailPage = async (props: {

--- a/src/components/Home/actions/index.ts
+++ b/src/components/Home/actions/index.ts
@@ -157,25 +157,30 @@ export const getOngoingPaginatedDocsCached = (query?: LocaleQuery) =>
     [query?.locale || DEFAULT_FALLBACK_LOCALE],
     {
       tags: ['home-events'],
+      revalidate: 86400, // 24 hours
     },
   )
 
 export const getPerformersCached = (query?: LocaleQuery) =>
   unstable_cache(async () => fetchPerformers(query), [query?.locale || DEFAULT_FALLBACK_LOCALE], {
     tags: ['home-performers'],
+    revalidate: 86400, // 24 hours
   })
 
 export const getPastEventsCached = (query?: LocaleQuery) =>
   unstable_cache(async () => fetchPastEvents(query), [query?.locale || DEFAULT_FALLBACK_LOCALE], {
     tags: ['home-events'],
+    revalidate: 86400, // 24 hours
   })
 
 export const getPartnersCached = (query?: LocaleQuery) =>
   unstable_cache(async () => fetchPartners(query), [query?.locale || DEFAULT_FALLBACK_LOCALE], {
     tags: ['home-partners'],
+    revalidate: 86400, // 24 hours
   })
 
 export const getActivitiesCached = (query?: LocaleQuery) =>
   unstable_cache(async () => fetchActivities(query), [query?.locale || DEFAULT_FALLBACK_LOCALE], {
     tags: ['home-activities'],
+    revalidate: 86400, // 24 hours
   })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Increased cache revalidation interval to 24 hours for event details, performers, ongoing documents, past events, partners, and activities, resulting in less frequent data refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->