### PR TITLE
fix: await handler execution in afterChangeStatus hooks

### DIFF
--- a/src/collections/Orders/hooks/afterChangeStatus.ts
+++ b/src/collections/Orders/hooks/afterChangeStatus.ts
@@ -87,7 +87,7 @@ export const afterChangeStatus = async ({ value, originalDoc, req }: FieldHookAr
       }
     }
 
-    handler()
+    await handler()
   }
   return value
 }

--- a/src/collections/Payments/hooks/afterChangeStatus.ts
+++ b/src/collections/Payments/hooks/afterChangeStatus.ts
@@ -62,7 +62,7 @@ export const afterChangeStatus = async ({ value, originalDoc, req }: FieldHookAr
       }
     }
 
-    handler()
+    await handler()
   }
   return value
 }


### PR DESCRIPTION
## What
+ This ensures that the handler functions complete before the hooks return, preventing potential race conditions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of order and payment status updates by ensuring all related operations complete before changes are finalized. This helps prevent incomplete updates and ensures all related actions, such as ticket updates and email notifications, are fully processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->