### PR TITLE
fix: add handle for 401

### DIFF
--- a/src/app/(frontend)/checkin/history/page.tsx
+++ b/src/app/(frontend)/checkin/history/page.tsx
@@ -53,6 +53,7 @@ export default function HistoryPage() {
 
         if (response.status === 401) {
           setToken('')
+          return
         }
 
         const data = await response.json()

--- a/src/app/(frontend)/checkin/history/page.tsx
+++ b/src/app/(frontend)/checkin/history/page.tsx
@@ -19,7 +19,7 @@ export default function HistoryPage() {
   const [checkins, setCheckins] = useState<CheckinRecord[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const router = useRouter()
-  const { token } = useAuth()
+  const { isHydrated, token, setToken } = useAuth()
   const [searchQuery, setSearchQuery] = useState('')
 
   const handleDelete = async (id: string) => {
@@ -51,6 +51,10 @@ export default function HistoryPage() {
           },
         })
 
+        if (response.status === 401) {
+          setToken('')
+        }
+
         const data = await response.json()
         setCheckins(data.records || [])
       } catch (err) {
@@ -71,6 +75,15 @@ export default function HistoryPage() {
     return matchesSearch
   })
 
+
+  useEffect(() => {
+    if (!isHydrated) return
+    if (!token) {
+      router.replace('/checkin')
+      return
+    }
+
+  }, [isHydrated, token, router])
   return (
     <div className="min-h-screen bg-white pt-16 px-6">
       {/* Header */}

--- a/src/app/(frontend)/checkin/validates/page.tsx
+++ b/src/app/(frontend)/checkin/validates/page.tsx
@@ -25,7 +25,7 @@ export default function ValidatePage() {
   const [isLoading, setIsLoading] = useState(false)
   const [multipleTickets, setMultipleTickets] = useState<any[]>([])
   const router = useRouter()
-  const { isHydrated, token } = useAuth()
+  const { isHydrated, token, setToken } = useAuth()
   const searchParams = useSearchParams()
 
   const eventId = searchParams?.get('eventId')
@@ -83,6 +83,10 @@ export default function ValidatePage() {
         body: JSON.stringify({ eventId, eventScheduleId: scheduleId }),
       })
       const data = await response.json()
+      if (response.status === 401) {
+        setToken('')
+        return
+      }
       if (response.status === 300 && data.tickets) {
         setMultipleTickets(data.tickets || [])
         return


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Users are now automatically redirected to the check-in page if not authenticated when accessing the history page.
  - Authentication tokens are cleared if an unauthorized (401) response is detected during check-in history fetch or validation, improving session security and preventing further unauthorized actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->