### PR TITLE
fix: Remove Link to Home

### DIFF
--- a/src/Header/Nav/Navbar.tsx
+++ b/src/Header/Nav/Navbar.tsx
@@ -45,7 +45,6 @@ const Navbar = ({ data, events }: { data: HeaderType; events: Event[] }) => {
 
   // Fixed navigation items based on requirements
   const navigationItems = [
-    { link: { label: 'Orchestars', url: '/' } },
     { link: { label: t('home.shows'), url: '#', isDropdown: true } },
     { link: { label: t('home.contact'), url: '#contact', onClick: scrollToFooter } },
   ]
@@ -73,6 +72,15 @@ const Navbar = ({ data, events }: { data: HeaderType; events: Event[] }) => {
         {/* Desktop Navigation */}
         <div className="hidden md:flex items-center justify-start flex-1">
           <div className="flex items-center space-x-8">
+            {navItems.map(({ link }, i) => (
+              <Link
+                key={link.url ?? link.label}
+                href={link.url || ''}
+                className="nav-link font-medium text-black/90 hover:text-black"
+              >
+                {link.label}
+              </Link>
+            ))}
             {navigationItems.map(({ link }, i) => (
               <div key={link.url ?? link.label} className="relative group">
                 {link.onClick ? (
@@ -116,15 +124,6 @@ const Navbar = ({ data, events }: { data: HeaderType; events: Event[] }) => {
                 )}
               </div>
             ))}
-            {navItems.map(({ link }, i) => (
-              <Link
-                key={link.url ?? link.label}
-                href={link.url || ''}
-                className="nav-link font-medium text-black/90 hover:text-black"
-              >
-                {link.label}
-              </Link>
-            ))}
           </div>
         </div>
 
@@ -141,6 +140,16 @@ const Navbar = ({ data, events }: { data: HeaderType; events: Event[] }) => {
             </SheetTrigger>
             <SheetContent side="right" className="bg-white border-gray-800">
               <div className="flex flex-col mt-10 space-y-6">
+                {navItems.map(({ link }, i) => (
+                  <Link
+                    key={link.url ?? link.label}
+                    href={link.url || ''}
+                    onClick={() => setIsOpen(false)}
+                    className="nav-link font-medium text-black/90 hover:text-black"
+                  >
+                    {link.label}
+                  </Link>
+                ))}
                 {navigationItems.map(({ link }, i) =>
                   link.onClick ? (
                     <a
@@ -182,16 +191,6 @@ const Navbar = ({ data, events }: { data: HeaderType; events: Event[] }) => {
                     </Link>
                   ),
                 )}
-                {navItems.map(({ link }, i) => (
-                  <Link
-                    key={link.url ?? link.label}
-                    href={link.url || ''}
-                    onClick={() => setIsOpen(false)}
-                    className="nav-link font-medium text-black/90 hover:text-black"
-                  >
-                    {link.label}
-                  </Link>
-                ))}
               </div>
             </SheetContent>
           </Sheet>

--- a/src/components/Home/components/PastConcerts.tsx
+++ b/src/components/Home/components/PastConcerts.tsx
@@ -42,7 +42,7 @@ const PastConcerts: React.FC<PastConcertsProps> = ({ events, className }) => {
                       className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-110"
                     />
                     {/* Hover overlay to show event information on desktop view*/}
-                    <div className="hidden absolute inset-0 bg-black/50 md:flex flex-col items-center justify-center p-4 opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                    <div className="hidden absolute inset-0 bg-black/70 md:flex flex-col items-center justify-center p-4 opacity-0 group-hover:opacity-100 transition-opacity duration-300">
                       <h3 className="text-white text-xl md:text-3xl line-clamp-3 font-bold mb-3 text-center">
                         {evt.title}
                       </h3>


### PR DESCRIPTION
# What

- Remove link to home on nav bar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Navigation menu now displays dynamic navigation items consistently across desktop and mobile views, with duplicate links removed.
  - In the Past Concerts section, the background overlay on event images is now darker on hover for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->