### PR TITLE
fix: Hide Carousel Buttons in Now Showing 

### DIFF
--- a/src/components/Home/components/NowShowingList.tsx
+++ b/src/components/Home/components/NowShowingList.tsx
@@ -85,7 +85,7 @@ const NowShowingList: React.FC<ConcertListProps> = ({ onGoingPaginatedDocs, clas
                   style={{ animationDelay: `${index * 0.1}s` }}
                 >
                   {/* Image section */}
-                  <div className="relative rounded-lg overflow-hidden w-full h-[250px] sm:h-[600px] lg:h-[890px] shadow-md">
+                  <div className="relative rounded-lg overflow-hidden w-full h-[250px] md:h-[600px] lg:h-[700px] xl:h-[890px] shadow-md">
                     <Image
                       fill
                       sizes="(max-width:768px) 100vw, 50vw"

--- a/src/components/Home/components/NowShowingList.tsx
+++ b/src/components/Home/components/NowShowingList.tsx
@@ -54,6 +54,8 @@ const NowShowingList: React.FC<ConcertListProps> = ({ onGoingPaginatedDocs, clas
     }
   }, [])
 
+  if (nowShowingEvents.length === 0) return null
+
   return (
     <section className={`py-10 md:py-20 ${className || ''}`}>
       <Carousel className="w-full relative">

--- a/src/components/Home/components/NowShowingList.tsx
+++ b/src/components/Home/components/NowShowingList.tsx
@@ -62,7 +62,7 @@ const NowShowingList: React.FC<ConcertListProps> = ({ onGoingPaginatedDocs, clas
             <h2 className="text-2xl md:text-4xl font-bold uppercase">
               {t('home.nowShowingEvents')}
             </h2>
-            {nowShowingEvents.length && (
+            {nowShowingEvents.length > 1 && (
               <div className="flex space-x-4">
                 <CarouselPrevious className="relative inset-0 translate-y-0 bg-black/30 hover:bg-black/80 hover:text-white text-white rounded-full h-10 w-10" />
                 <CarouselNext className="relative inset-0 translate-y-0 bg-black/30 hover:bg-black/80 hover:text-white text-white rounded-full h-10 w-10" />


### PR DESCRIPTION
# What

- Hide carousel buttons in Now Showing, if there is only 1 now showing event

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- The section for currently showing events will no longer appear if there are no events to display.
	- Carousel navigation buttons now appear only when there is more than one event.

- **Style**
	- Improved responsive image container heights for better display across different screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->