### PR TITLE
feat: Show Past Events on Top Fold Banner

### DIFF
--- a/src/components/Home/Component.client.tsx
+++ b/src/components/Home/Component.client.tsx
@@ -63,7 +63,7 @@ const HomeClient = ({
   return (
     <div className="min-h-screen flex flex-col">
       <main className="flex-grow pt-2 md:pt-6">
-        <ConcertBanner events={bannerDocs} />
+        <ConcertBanner events={[...bannerDocs, ...pastEvents]} />
         {visibleSections.map((section, index) => (
           <section.Component key={index} {...section.props} />
         ))}

--- a/src/components/Home/components/ConcertBanner.tsx
+++ b/src/components/Home/components/ConcertBanner.tsx
@@ -43,6 +43,7 @@ const ConcertBanner: React.FC<EventBannerProps> = ({ events = [] }) => {
     (evt: Event, index: number) => {
       const isUpcoming = evt.status === EVENT_STATUS.published_upcoming.value
       const isNowShowing = evt.status === EVENT_STATUS.published_open_sales.value
+      const isPast = evt.status === EVENT_STATUS.completed.value
 
       const Banner = (
         <>
@@ -66,7 +67,7 @@ const ConcertBanner: React.FC<EventBannerProps> = ({ events = [] }) => {
       if (!isMobile) {
         return (
           <div
-            key={evt.id}
+            key={`${index}-${evt.title}`}
             className={`absolute inset-0 transition-opacity duration-1000 ${
               index === currentIndex ? 'opacity-100' : 'opacity-0 pointer-events-none'
             }`}
@@ -119,16 +120,19 @@ const ConcertBanner: React.FC<EventBannerProps> = ({ events = [] }) => {
                   <span className="max-w-[600px] font-medium text-lg mb-6">{evt.description}</span>
                 )}
 
-                <Link
-                  href={`/events/${evt.slug}`}
-                  className="inline-block w-fit px-6 py-3 bg-white text-black font-semibold rounded-lg hover:bg-gray-200 transition-colors"
-                >
-                  {evt.status === EVENT_STATUS.published_open_sales.value && t('home.bookTicket')}
-                  {evt.status === EVENT_STATUS.published_upcoming.value && t('home.upcomingEvents')}
-                  {evt.status !== EVENT_STATUS.published_open_sales.value &&
-                    evt.status !== EVENT_STATUS.published_upcoming.value &&
-                    t('home.viewDetail')}
-                </Link>
+                {!isPast && (
+                  <Link
+                    href={`/events/${evt.slug}`}
+                    className="inline-block w-fit px-6 py-3 bg-white text-black font-semibold rounded-lg hover:bg-gray-200 transition-colors"
+                  >
+                    {evt.status === EVENT_STATUS.published_open_sales.value && t('home.bookTicket')}
+                    {evt.status === EVENT_STATUS.published_upcoming.value &&
+                      t('home.upcomingEvents')}
+                    {evt.status !== EVENT_STATUS.published_open_sales.value &&
+                      evt.status !== EVENT_STATUS.published_upcoming.value &&
+                      t('home.viewDetail')}
+                  </Link>
+                )}
               </div>
             </div>
           </div>
@@ -138,7 +142,7 @@ const ConcertBanner: React.FC<EventBannerProps> = ({ events = [] }) => {
       // show on mobile
       return (
         <Link
-          key={evt.id}
+          key={`${index}-${evt.title}`}
           href={`/events/${evt.slug}`}
           className={`absolute inset-0 transition-opacity duration-1000 ${
             index === currentIndex ? 'opacity-100' : 'opacity-0 pointer-events-none'
@@ -205,9 +209,9 @@ const ConcertBanner: React.FC<EventBannerProps> = ({ events = [] }) => {
       )}
 
       <div className="absolute bottom-4 md:bottom-8 left-0 right-0 z-30 flex justify-center gap-2">
-        {events?.map((_, index) => (
+        {events?.map((evt, index) => (
           <button
-            key={index}
+            key={`${index}-${evt.title}`}
             onClick={() => handleDotClick(index)}
             className={`h-2 rounded-full transition-all border border-white ${
               index === currentIndex ? 'w-8 bg-black/50' : 'w-2 bg-black/50 hover:bg-black/80'

--- a/src/components/Home/components/ConcertBanner.tsx
+++ b/src/components/Home/components/ConcertBanner.tsx
@@ -42,8 +42,13 @@ const ConcertBanner: React.FC<EventBannerProps> = ({ events = [] }) => {
   const renderBanners = useCallback(
     (evt: Event, index: number) => {
       const isUpcoming = evt.status === EVENT_STATUS.published_upcoming.value
-      const isNowShowing = evt.status === EVENT_STATUS.published_open_sales.value
-      const isPast = evt.status === EVENT_STATUS.completed.value
+      const isNowShowing =
+        evt.status === EVENT_STATUS.published_open_sales.value &&
+        evt?.endDatetime &&
+        new Date(evt?.endDatetime) > new Date()
+      const isPast =
+        evt.status === EVENT_STATUS.completed.value ||
+        (evt?.endDatetime && new Date(evt?.endDatetime) < new Date())
 
       const Banner = (
         <>
@@ -120,19 +125,14 @@ const ConcertBanner: React.FC<EventBannerProps> = ({ events = [] }) => {
                   <span className="max-w-[600px] font-medium text-lg mb-6">{evt.description}</span>
                 )}
 
-                {!isPast && (
-                  <Link
-                    href={`/events/${evt.slug}`}
-                    className="inline-block w-fit px-6 py-3 bg-white text-black font-semibold rounded-lg hover:bg-gray-200 transition-colors"
-                  >
-                    {evt.status === EVENT_STATUS.published_open_sales.value && t('home.bookTicket')}
-                    {evt.status === EVENT_STATUS.published_upcoming.value &&
-                      t('home.upcomingEvents')}
-                    {evt.status !== EVENT_STATUS.published_open_sales.value &&
-                      evt.status !== EVENT_STATUS.published_upcoming.value &&
-                      t('home.viewDetail')}
-                  </Link>
-                )}
+                <Link
+                  href={`/events/${evt.slug}`}
+                  className="inline-block w-fit px-6 py-3 bg-white text-black font-semibold rounded-lg hover:bg-gray-200 transition-colors"
+                >
+                  {isNowShowing && t('home.bookTicket')}
+                  {isUpcoming && t('home.upcomingEvents')}
+                  {isPast && t('home.viewDetail')}
+                </Link>
               </div>
             </div>
           </div>

--- a/src/components/Home/components/NowShowingList.tsx
+++ b/src/components/Home/components/NowShowingList.tsx
@@ -26,7 +26,9 @@ const NowShowingList: React.FC<ConcertListProps> = ({ onGoingPaginatedDocs, clas
   const nowShowingEvents = useMemo(
     () =>
       onGoingPaginatedDocs?.docs.filter(
-        (evt) => evt.status === EVENT_STATUS.published_open_sales.value,
+        (evt) =>
+          evt.status === EVENT_STATUS.published_open_sales.value &&
+          new Date(evt.endDatetime) > new Date(),
       ),
     [onGoingPaginatedDocs?.docs],
   )


### PR DESCRIPTION
# What

- Include past events on the banner, to avoid empty top fold, when current event is over

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Combined current and past events into a unified concert banner display.
  - Refined event status indicators to clearly distinguish now showing, upcoming, and past events.
  - Updated event listings to exclude ended events from the now showing section. 
  - Enhanced navigation and banner element stability for a smoother user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->