### PR TITLE
feat: Modify Description on Homepage Top Fold

### DIFF
--- a/src/components/Home/components/ConcertBanner.tsx
+++ b/src/components/Home/components/ConcertBanner.tsx
@@ -122,7 +122,9 @@ const ConcertBanner: React.FC<EventBannerProps> = ({ events = [] }) => {
                 </div>
 
                 {evt.configuration?.showBannerDescription && (
-                  <span className="max-w-[600px] font-medium text-lg mb-6">{evt.description}</span>
+                  <span className="max-w-[600px] font-medium text-lg mb-6 line-clamp-5">
+                    {evt.description}
+                  </span>
                 )}
 
                 <Link

--- a/src/components/Home/components/ConcertBanner.tsx
+++ b/src/components/Home/components/ConcertBanner.tsx
@@ -122,7 +122,7 @@ const ConcertBanner: React.FC<EventBannerProps> = ({ events = [] }) => {
                 </div>
 
                 {evt.configuration?.showBannerDescription && (
-                  <span className="max-w-[600px] font-medium text-lg mb-6 line-clamp-5">
+                  <span className="max-w-[600px] font-medium text-lg mb-6 line-clamp-4">
                     {evt.description}
                   </span>
                 )}


### PR DESCRIPTION
# What

- Modify event description on homepage top fold, to have maximum of 4 lines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Limited event description in the concert banner to a maximum of five lines, ensuring a cleaner and more consistent appearance on desktop devices. Overflowing text will now be truncated with an ellipsis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->