### PR TITLE
feat: add SEO fields to header and fallback to header SEO on pages

### DIFF
--- a/src/Header/config.ts
+++ b/src/Header/config.ts
@@ -22,6 +22,31 @@ export const Header: GlobalConfig = {
       localized: true,
     },
     {
+      name: 'seo',
+      label: 'SEO',
+      type: 'group',
+      fields: [
+        {
+          name: 'title',
+          type: 'text',
+          localized: true,
+        },
+        {
+          name: 'description',
+          type: 'textarea',
+          localized: true,
+        },
+        {
+          name: 'image',
+          type: 'upload',
+          relationTo: 'media',
+          admin: {
+            description: 'Image used for social media link previews (recommended 1200x630 px).',
+          },
+        },
+      ],
+    },
+    {
       name: 'navItems',
       type: 'array',
       fields: [

--- a/src/app/(frontend)/[slug]/page.tsx
+++ b/src/app/(frontend)/[slug]/page.tsx
@@ -17,6 +17,10 @@ import { RenderPageBreadcrumb } from '@/page-breadcrumb/RenderPageBreadcrumb'
 import { RenderPageBanner } from '@/page-banner/RenderPageBanner'
 import { getLocale } from '@/providers/I18n/server'
 import { DEFAULT_FALLBACK_LOCALE, SupportedLocale } from '@/config/app'
+import { getCachedGlobal } from '@/utilities/getGlobals'
+import type { Header as HeaderType } from '@/payload-types'
+
+
 
 export const dynamic = 'force-dynamic' // Force dynamic rendering
 export const revalidate = 3600
@@ -117,7 +121,16 @@ export async function generateMetadata({ params: paramsPromise }: Args): Promise
     locale
   })
 
-  return generateMeta({ doc: page })
+  const headerData: HeaderType = await getCachedGlobal('header', 1, locale)()
+
+  return generateMeta({ doc: {
+    ...page,
+    meta: {
+      title: page?.meta?.title || headerData?.seo?.title,
+      description: page?.meta?.description || headerData?.seo?.description,
+      image: page?.meta?.image || headerData?.seo?.image,
+    }
+  } })
 }
 
 const queryPageBySlug = cache(async ({ slug, locale }: { slug: string, locale?: SupportedLocale }) => {

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -2832,6 +2832,14 @@ export interface Header {
   id: number;
   logo?: (number | null) | Media;
   title?: string | null;
+  seo?: {
+    title?: string | null;
+    description?: string | null;
+    /**
+     * Image used for social media link previews (recommended 1200x630 px).
+     */
+    image?: (number | null) | Media;
+  };
   navItems?:
     | {
         link: {
@@ -2927,6 +2935,13 @@ export interface Footer {
 export interface HeaderSelect<T extends boolean = true> {
   logo?: T;
   title?: T;
+  seo?:
+    | T
+    | {
+        title?: T;
+        description?: T;
+        image?: T;
+      };
   navItems?:
     | T
     | {


### PR DESCRIPTION
## ✨ Summary by Git AI

### 🔥 Changes
- Added SEO fields (title, description, image) to the header configuration.
- Implemented fallback to header SEO fields for page metadata if page-specific metadata is missing.
- Updated payload types to include new SEO fields in the header.
              