### PR TITLE
feat: update ticket booking email template for Disney events

### DIFF
--- a/src/collections/Tickets/hooks/afterChangeSeat.ts
+++ b/src/collections/Tickets/hooks/afterChangeSeat.ts
@@ -1,6 +1,8 @@
 import { FieldHookArgs } from 'payload'
-import { generateTicketBookEmailHtml } from '@/mail/templates/TicketBookedEmail'
+// import { generateTicketBookEmailHtml } from '@/mail/templates/TicketBookedEmail'
 import { sendMailAndWriteLog } from '@/collections/Emails/utils'
+import { toZonedTime, format as tzFormat } from 'date-fns-tz'
+import { generateTicketDisneyEventBookEmailHtml } from '@/mail/templates/TicketDisneyEventBookedEmail'
 
 export const afterChangeSeat = async ({ value, originalDoc, data, req }: FieldHookArgs) => {
   if (originalDoc.status === 'booked' && data?.allowSendMailAfterChanged) {
@@ -25,11 +27,20 @@ export const afterChangeSeat = async ({ value, originalDoc, data, req }: FieldHo
           .catch(() => null)
 
         if (user?.email) {
-          const html = await generateTicketBookEmailHtml({
+          const startTime = event?.startDatetime
+            ? tzFormat(toZonedTime(new Date(event.startDatetime), 'Asia/Ho_Chi_Minh'), 'HH:mm')
+            : ''
+          const endTime = event?.endDatetime
+            ? tzFormat(toZonedTime(new Date(event.endDatetime), 'Asia/Ho_Chi_Minh'), 'HH:mm')
+            : ''
+          const eventLocation = event?.eventLocation as string
+
+          const html = await generateTicketDisneyEventBookEmailHtml({
             ticketCode: originalDoc.ticketCode,
             eventName: event?.title || '',
-            eventDate: originalDoc?.eventDate || '',
+            eventDate: `${startTime || 'N/A'} - ${endTime || 'N/A'}, ${originalDoc?.eventDate || 'N/A'} (Giờ Việt Nam | Vietnam Time, GMT+7)`,
             seat: value,
+            eventLocation,
           })
 
           const resendMailData = {


### PR DESCRIPTION
## ✨ Summary by Git AI

### 🔥 Changes
- Replaced the generic ticket booking email template with a Disney-themed one.
- Added event start and end times (formatted in Vietnam Time, GMT+7) to the email.
- Included event location information in the email.
- Modified date format in email.

## Summary by Sourcery

Use the Disney event booking email template to send tickets with formatted start/end times, location, and updated date formatting.

New Features:
- Switch ticket booking emails to a Disney-themed template instead of the generic one
- Include event start and end times formatted in Vietnam Time (GMT+7) in the email
- Add event location information to the booking confirmation email
- Enhance date formatting to combine times, date, and timezone label in the email

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced ticket booking emails with detailed event timing (including start and end times, localized to "Asia/Ho_Chi_Minh" timezone) and event location.
  - Updated email subject lines to include "Update_" and the event title for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->