### PR TITLE
feat: add execute mail job endpoint and cron schedule

### DIFF
--- a/src/app/(payload)/api/execute-mail-job/route.ts
+++ b/src/app/(payload)/api/execute-mail-job/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server'
+import { sendMailJob } from '@/collections/Emails/jobs/sendMail'
+import { getPayload } from '@/payload-config/getPayloadConfig'
+import { getServerSideURL } from '@/utilities/getURL'
+
+export async function GET(req: Request) {
+  try {
+    // Check for authorization header
+    const authHeader = req.headers.get('authorization')
+    if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+      return NextResponse.json(
+        { error: 'Unauthorized' },
+        { status: 401 }
+      )
+    }
+
+    // Validate request origin
+    const origin = req.headers.get('origin')
+    const referer = req.headers.get('referer')
+    const serverUrl = getServerSideURL()
+    
+    // Allow requests from Vercel cron jobs (no origin/referer) or from the same domain
+    const isValidOrigin = !origin || origin === serverUrl
+    const isValidReferer = !referer || referer.startsWith(serverUrl)
+    
+    if (!isValidOrigin || !isValidReferer) {
+      return NextResponse.json(
+        { error: 'Invalid request origin' },
+        { status: 403 }
+      )
+    }
+
+    // Initialize Payload
+    const payload = await getPayload()
+
+    // Execute the mail job
+    await sendMailJob({ payload })
+
+    return NextResponse.json(
+      { message: 'Mail job executed successfully' },
+      { status: 200 }
+    )
+  } catch (error) {
+    console.error('Error executing mail job:', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -40,12 +40,12 @@ import { IS_LOCAL_DEVELOPMENT } from './config/app'
 import { SeatingCharts } from './collections/SeatingCharts'
 import { MarketingTracking } from './collections/MarketingTracking'
 import { PromotionConfigs } from './collections/Promotion/PromotionConfigs'
-import { sendMailJob } from './collections/Emails/jobs/sendMail'
+// import { sendMailJob } from './collections/Emails/jobs/sendMail'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
-let initializedSendMailJob = false
+// let initializedSendMailJob = false
 
 export default buildConfig({
   admin: {
@@ -148,21 +148,21 @@ export default buildConfig({
   typescript: {
     outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
-  onInit: async (payload) => {
-    console.log('SKIP_PAYLOAD_INIT', process.env.SKIP_PAYLOAD_INIT === 'true')
-    if (process.env.SKIP_PAYLOAD_INIT === 'true') {
-      return
-    }
-    if (!initializedSendMailJob) {
-      console.log('-->payload onInit fired')
-      // todo, using env instead
-      const TIME_OUT = 60000
-      initializedSendMailJob = true
-      setInterval(() => {
-        sendMailJob({ payload })
-      }, TIME_OUT)
-    }
-  },
+  // onInit: async (payload) => {
+  //   console.log('SKIP_PAYLOAD_INIT', process.env.SKIP_PAYLOAD_INIT === 'true')
+  //   if (process.env.SKIP_PAYLOAD_INIT === 'true') {
+  //     return
+  //   }
+  //   if (!initializedSendMailJob) {
+  //     console.log('-->payload onInit fired')
+  //     // todo, using env instead
+  //     const TIME_OUT = 60000
+  //     initializedSendMailJob = true
+  //     setInterval(() => {
+  //       sendMailJob({ payload })
+  //     }, TIME_OUT)
+  //   }
+  // },
   jobs: {
     access: {
       run: ({ req }: { req: PayloadRequest }): boolean => {

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,10 @@
     {
       "path": "/api/payload-jobs/run",
       "schedule": "*/5 * * * *"
+    },
+    {
+      "path": "/api/execute-mail-job",
+      "schedule": "* * * * *"
     }
   ]
 }


### PR DESCRIPTION
## ✨ Summary by Git AI

### 🔥 Changes
- Added a new API endpoint `/api/execute-mail-job` to trigger the mail job.
- Implemented authorization and origin validation for the endpoint.
- Configured a cron job to execute the mail job every minute.
- Removed initialization of sendMailJob from payload.config.ts.
- Added a check for valid origin and referer headers to prevent unauthorized access.

## Summary by Sourcery

Add a secured HTTP endpoint to execute the mail job via cron and deprecate the built-in payload onInit scheduler.

New Features:
- Expose a GET /api/execute-mail-job endpoint to trigger the mail job on demand

Enhancements:
- Require a Bearer token and validate request origin and referer for the mail job endpoint
- Remove the legacy onInit-based mail job scheduler in payload.config.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new API endpoint to manually trigger the mail job.

- **Chores**
  - Disabled automatic periodic mail job execution within the app.
  - Scheduled the mail job to run every minute using Vercel's cron job configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->