### PR TITLE
fix: disable origin validation for execute-mail-job route

### DIFF
--- a/src/app/(payload)/api/execute-mail-job/route.ts
+++ b/src/app/(payload)/api/execute-mail-job/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { sendMailJob } from '@/collections/Emails/jobs/sendMail'
 import { getPayload } from '@/payload-config/getPayloadConfig'
-import { getServerSideURL } from '@/utilities/getURL'
+// import { getServerSideURL } from '@/utilities/getURL'
 
 export async function GET(req: Request) {
   try {
@@ -15,20 +15,20 @@ export async function GET(req: Request) {
     }
 
     // Validate request origin
-    const origin = req.headers.get('origin')
-    const referer = req.headers.get('referer')
-    const serverUrl = getServerSideURL()
+    // const origin = req.headers.get('origin')
+    // const referer = req.headers.get('referer')
+    // const serverUrl = getServerSideURL()
     
-    // Allow requests from Vercel cron jobs (no origin/referer) or from the same domain
-    const isValidOrigin = !origin || origin === serverUrl
-    const isValidReferer = !referer || referer.startsWith(serverUrl)
+    // // Allow requests from Vercel cron jobs (no origin/referer) or from the same domain
+    // const isValidOrigin = !origin || origin === serverUrl
+    // const isValidReferer = !referer || referer.startsWith(serverUrl)
     
-    if (!isValidOrigin || !isValidReferer) {
-      return NextResponse.json(
-        { error: 'Invalid request origin' },
-        { status: 403 }
-      )
-    }
+    // if (!isValidOrigin || !isValidReferer) {
+    //   return NextResponse.json(
+    //     { error: 'Invalid request origin' },
+    //     { status: 403 }
+    //   )
+    // }
 
     // Initialize Payload
     const payload = await getPayload()


### PR DESCRIPTION
## ✨ Summary by Git AI

### 🔥 Changes
- Temporarily disabled origin and referer validation in the execute-mail-job route.
- This allows requests without origin or referer headers, like those from Vercel cron jobs, to execute the mail job.

## Summary by Sourcery

Bug Fixes:
- Allow execute-mail-job requests without origin or referer by disabling header validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed validation of request origin and referer headers for mail job execution requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->