### PR TITLE
refactor: rename execute-send-email to cron/send-email

### DIFF
--- a/src/app/api/cron/send-email/route.ts
+++ b/src/app/api/cron/send-email/route.ts
@@ -1,12 +1,12 @@
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { sendMailJob } from '@/collections/Emails/jobs/sendMail'
 import { getPayload } from '@/payload-config/getPayloadConfig'
 // import { getServerSideURL } from '@/utilities/getURL'
 
-export async function GET(req: Request) {
+export async function GET(req: NextRequest) {
   try {
     // Check for authorization header
-    console.log('--> executing /api/execute-send-email\n')
+    console.log('--> executing /api/cron/send-email\n')
     const authHeader = req.headers.get('authorization')
     if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
       return NextResponse.json(

--- a/src/app/api/cron/send-email/route.ts
+++ b/src/app/api/cron/send-email/route.ts
@@ -3,6 +3,8 @@ import { sendMailJob } from '@/collections/Emails/jobs/sendMail'
 import { getPayload } from '@/payload-config/getPayloadConfig'
 // import { getServerSideURL } from '@/utilities/getURL'
 
+export const dynamic = 'force-dynamic'
+
 export async function GET(req: NextRequest) {
   try {
     // Check for authorization header

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "crons": [
     {
-      "path": "/api/execute-send-email",
+      "path": "/api/cron/send-email",
       "schedule": "* * * * *"
     },
     {


### PR DESCRIPTION
## ✨ Summary by Git AI

### 🔥 Changes
- Renamed the `execute-send-email` route to `cron/send-email` to better reflect its purpose as a cron job.
- Updated the `vercel.json` configuration to use the new route path for the cron job.

## Summary by Sourcery

Refactor the send-email cron job endpoint by renaming its route and updating related code and configuration.

Enhancements:
- Rename the API route from execute-send-email to cron/send-email
- Update the route handler to use NextRequest and adjust the console log message
- Update vercel.json to point the cron job to the new route path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the scheduled email-sending API route path to "/api/cron/send-email".
  - Adjusted related logging to reflect the new API route path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->