### PR TITLE
refactor: Hide legacy promotionCode field and migrate data

### DIFF
--- a/src/collections/Orders/index.ts
+++ b/src/collections/Orders/index.ts
@@ -61,6 +61,7 @@ export const Orders: CollectionConfig = {
       admin: {
         description: 'Legacy field for a single promotion. Use "promotionsApplied" instead.',
       },
+      hidden: true,
     },
     {
       name: 'promotionCode',
@@ -69,6 +70,21 @@ export const Orders: CollectionConfig = {
       index: true,
       admin: {
         description: 'Legacy field for a single promotion. Use "promotionsApplied" instead.',
+        readOnly: true,
+      },
+      hooks: {
+        afterRead: [
+          async ({  data }) => {
+            if (data?.promotionsApplied?.length) {
+              return data.promotionsApplied
+                .map((promo: any) => promo.promotionCode)
+                .filter((exist: string) => !!exist)
+                .join(', ')
+            }
+
+            return data?.promotionCode
+          },
+        ],
       },
     },
     {

--- a/src/collections/Payments/index.ts
+++ b/src/collections/Payments/index.ts
@@ -39,6 +39,7 @@ export const Payments: CollectionConfig = {
       admin: {
         description: 'Legacy field for a single promotion. Use "promotionsApplied" instead.',
       },
+      hidden: true,
     },
     {
       name: 'promotionCode',
@@ -47,6 +48,21 @@ export const Payments: CollectionConfig = {
       required: false,
       admin: {
         description: 'Legacy field for a single promotion. Use "promotionsApplied" instead.',
+        readOnly: true,
+      },
+      hooks: {
+        afterRead: [
+          async ({  data }) => {
+            if (data?.promotionsApplied?.length) {
+              return data.promotionsApplied
+                .map((promo: any) => promo.promotionCode)
+                .filter((exist: string) => !!exist)
+                .join(', ')
+            }
+
+            return data?.promotionCode
+          },
+        ],
       },
     },
     {


### PR DESCRIPTION
## ✨ Summary by Git AI

### 🔥 Changes
- Hides the legacy `promotionCode` field in Orders and Payments collections.
- Adds `afterRead` hook to populate `promotionCode` from `promotionsApplied` if available for backward compatibility.
- Sets `readOnly: true` for `promotionCode` to prevent direct modification.

## Summary by Sourcery

Hide the deprecated promotionCode field in Orders and Payments while maintaining backward compatibility by deriving its value from promotionsApplied and enforcing it as read-only.

Enhancements:
- Hide the legacy promotionCode field in Orders and Payments collections
- Populate promotionCode via an afterRead hook that aggregates codes from promotionsApplied
- Mark promotionCode as read-only to prevent direct modifications

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The promotion field is now hidden in the admin interface for Orders and Payments.
	- The promotion code field is now read-only in the admin UI for Orders and Payments.
	- The promotion code field dynamically displays a list of all applied promotion codes if available, improving clarity when multiple promotions are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->