### PR TITLE
feat: configure cron job and send email

### DIFF
--- a/src/app/api/cron/send-email/route.ts
+++ b/src/app/api/cron/send-email/route.ts
@@ -4,6 +4,7 @@ import { getPayload } from '@/payload-config/getPayloadConfig'
 // import { getServerSideURL } from '@/utilities/getURL'
 
 export const dynamic = 'force-dynamic'
+export const maxDuration = 120; 
 
 export async function GET(req: NextRequest) {
   try {
@@ -37,7 +38,7 @@ export async function GET(req: NextRequest) {
     const payload = await getPayload()
 
     // Execute the mail job
-    await sendMailJob({ payload })
+    sendMailJob({ payload })
 
     return NextResponse.json(
       { message: 'Mail job executed successfully' },

--- a/src/collections/Emails/jobs/sendMail.ts
+++ b/src/collections/Emails/jobs/sendMail.ts
@@ -26,9 +26,15 @@ export const sendMailJob = async ({ payload }: { payload: BasePayload }) => {
       depth: 0,
     })
 
-    console.log(`---> Total mail sending ${pendingEmails.docs?.length}\n`)
+    const emails = pendingEmails.docs
 
-    for (const email of pendingEmails.docs) {
+    if (!emails.length) {
+      return
+    }
+
+    console.log(`---> Total mail sending ${emails?.length}\n`)
+
+    for (const email of emails) {
       const resendMailData = {
         to: email.to,
         cc: email.cc as string,

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/cron/send-email",
-      "schedule": "* * * * *"
+      "schedule": "*/2 * * * *"
     },
     {
       "path": "/api/payload-jobs/run",


### PR DESCRIPTION
## ✨ Summary by Git AI

### 🔥 Changes
- Set maxDuration for the cron job to 120 seconds.
- Schedule the cron job to run every 2 minutes.
- Remove await from sendMailJob execution in the cron endpoint.
- Return early from sendMailJob if there are no pending emails.

## Summary by Sourcery

Configure and optimize the email-sending cron job by scheduling it every 2 minutes, enforcing a 120-second timeout, running it asynchronously, and skipping execution when no emails are pending.

New Features:
- Configure cron job to run every two minutes
- Set maxDuration to 120 seconds for the cron endpoint

Enhancements:
- Run sendMailJob without awaiting to avoid blocking the endpoint
- Exit early when there are no pending emails to process
- Cache pending emails list for consistent logging and iteration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the email sending cron job schedule to run every two minutes instead of every minute.
  - Improved internal handling and logging for pending emails to optimize processing and reduce unnecessary operations.
- **New Features**
  - The email sending endpoint now responds more quickly by triggering the mail job asynchronously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->