### PR TITLE
feat: Fetch promotions and config from separate API endpoints

### DIFF
--- a/src/components/AdminViews/Order/CreateOrderForm.tsx
+++ b/src/components/AdminViews/Order/CreateOrderForm.tsx
@@ -238,18 +238,38 @@ export const CreateOrderForm: React.FC<{ events: Event[] }> = ({ events }) => {
 
     Promise.all([
       fetch(`/api/promotions?${queryPromotion}`)
-        .then((res) => res.json())
+        .then((res) => {
+          if (!res.ok) {
+            return res.text().then((text) => {
+              throw new Error(
+                `Failed to fetch promotions: ${res.status} ${res.statusText} - ${text}`,
+              )
+            })
+          }
+          return res.json()
+        })
         .catch((err) => {
-          console.log('Error while fetching promotions', err)
+          console.error('Error while fetching promotions', err)
+          return { docs: [] }
         }),
       fetch(`/api/promotionConfigs?${queryConfigPromotion}`)
-        .then((res) => res.json())
+        .then((res) => {
+          if (!res.ok) {
+            return res.text().then((text) => {
+              throw new Error(
+                `Failed to fetch promotion config: ${res.status} ${res.statusText} - ${text}`,
+              )
+            })
+          }
+          return res.json()
+        })
         .catch((err) => {
-          console.log('Error while fetching promotion config', err)
+          console.error('Error while fetching promotion config', err)
+          return { docs: [] }
         }),
     ]).then((result) => {
       const promotions = result?.[0]?.docs || []
-      const eventPromotionConfig = result?.[1]?.docs?.[0] || []
+      const eventPromotionConfig = result?.[1]?.docs?.[0]
       setPromotions(promotions)
       setEventPromotionConfig(eventPromotionConfig)
     })


### PR DESCRIPTION
## ✨ Summary by Git AI

### 🔥 Changes
- Refactor promotion data fetching to use separate API endpoints for promotions and promotion configurations.
- Update promotion data fetching logic to filter active promotions based on start and end dates.
- Enhance promotion data fetching with query parameters for filtering and selection.
- Improve error handling during promotion and promotion config data fetching.
- Update the query for promotion to include the conditions and discountApplyScope fields.
- Add query parameter to limit the number of promotions.

## Summary by Sourcery

Fetch promotion data and configuration from distinct API endpoints with date-based filtering and optimized parallel requests

New Features:
- Fetch promotions and promotion configurations separately via `/api/promotions` and `/api/promotionConfigs` endpoints

Enhancements:
- Filter promotions by active status and current date while selecting only required fields and limiting results
- Run promotion and config requests in parallel using `Promise.all` and improve error logging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability of promotion and promotion configuration fetching when selecting an event during order creation.

- **Style**
	- Minor formatting and indentation adjustments for improved code readability.

No visible changes to user interface or workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->