### PR TITLE
feat(auth): send affiliate setup email on user creation

### DIFF
--- a/src/collections/Emails/utils/index.ts
+++ b/src/collections/Emails/utils/index.ts
@@ -3,11 +3,13 @@ import { Email } from '@/payload-types'
 import { BasePayload } from 'payload'
 import { EMAIL_DEFAULT_FROM_ADDRESS, EMAIL_PROVIDER } from '@/config/email'
 import { logError } from '@/collections/Logs/utils'
+import { TransactionID } from '@/types/TransactionID'
 
 export const sendMailAndWriteLog = async ({
   resendMailData,
   emailData,
   payload,
+  transactionID
 }: {
   resendMailData: {
     to: string
@@ -17,6 +19,7 @@ export const sendMailAndWriteLog = async ({
   }
   emailData: Partial<Email>
   payload: BasePayload
+  transactionID?: TransactionID
 }) => {
   const resendResult = await sendMail({ payload, mailData: resendMailData })
 
@@ -31,6 +34,7 @@ export const sendMailAndWriteLog = async ({
         status: 'sent'
       },
       payload,
+      transactionID
     })
   }
 }
@@ -70,14 +74,18 @@ const sendMail = async ({
 const createEmailRecord = async ({
   data,
   payload,
+  transactionID
 }: {
   payload: BasePayload
   data: Partial<Email>
+  transactionID?: TransactionID
 }) => {
   try {
     return payload.create({
       collection: 'emails',
       data: data as any,
+      req: { transactionID },
+      depth: 0,
     })
   } catch (error: any) {
     console.error('Error while writing email log', error)

--- a/src/collections/Users/hooks/sendAffiliateSetupEmail.ts
+++ b/src/collections/Users/hooks/sendAffiliateSetupEmail.ts
@@ -1,0 +1,47 @@
+import type { CollectionAfterChangeHook } from 'payload'
+import { sendMailAndWriteLog } from '@/collections/Emails/utils'
+import { getServerSideURL } from '@/utilities/getURL'
+import { affiliateAccountSetupEmailHtml } from '@/mail/templates/AffiliateAccountSetup'
+import { setUserResetPasswordToken } from '@/collections/Users/utils/setUserResetPasswordToken'
+
+export const sendAffiliateSetupEmail: CollectionAfterChangeHook = async ({
+  doc,
+  req,
+  operation,
+}) => {
+  // Only trigger for create operations and affiliate users
+
+  if (operation !== 'create' || doc.role !== 'affiliate') {
+    return doc
+  }
+
+  try {
+    const { payload, transactionID } = req
+
+    // Generate setup token (reusing the reset password token mechanism)
+    const setupToken = await setUserResetPasswordToken({ userId: doc.id, transactionID })
+
+    // Build affiliate-specific setup link
+    const setupLink = `${getServerSideURL()}/affiliate/reset-password?token=${setupToken}`
+
+    // Send setup email
+    await sendMailAndWriteLog({
+      resendMailData: {
+        to: doc.email,
+        subject: 'Welcome to OrcheStars Affiliate Program - Set Up Your Password',
+        html: affiliateAccountSetupEmailHtml({ setupLink }),
+      },
+      emailData: { user: doc.id },
+      payload,
+      transactionID
+    })
+
+    console.log(`Affiliate setup email sent to: ${doc.email}`)
+  } catch (error) {
+    console.error('Error sending affiliate setup email:', error)
+    // Don't throw error to prevent user creation from failing
+    // The user can still use forgot password if needed
+  }
+
+  return doc
+}

--- a/src/collections/Users/index.ts
+++ b/src/collections/Users/index.ts
@@ -1,4 +1,5 @@
 import type { CollectionConfig } from 'payload'
+import { sendAffiliateSetupEmail } from './hooks/sendAffiliateSetupEmail'
 
 export const Users: CollectionConfig = {
   slug: 'users',
@@ -96,4 +97,7 @@ export const Users: CollectionConfig = {
       // admin: { position: 'sidebar' },
     },
   ],
+  hooks: {
+    afterChange: [sendAffiliateSetupEmail],
+  },
 }

--- a/src/collections/Users/utils/setUserResetPasswordToken.ts
+++ b/src/collections/Users/utils/setUserResetPasswordToken.ts
@@ -1,8 +1,15 @@
 import { getPayload } from '@/payload-config/getPayloadConfig'
 import { User } from '@/payload-types'
+import { TransactionID } from '@/types/TransactionID'
 import { generateResetToken } from '@/utilities/generateResetToken'
 
-export const setUserResetPasswordToken = async ({ userId }: { userId: User['id'] }) => {
+export const setUserResetPasswordToken = async ({
+  userId,
+  transactionID
+}: {
+  userId: User['id']
+  transactionID?: TransactionID
+}) => {
   const payload = await getPayload()
   // Generate reset token and expiration
   const resetToken = generateResetToken()
@@ -16,6 +23,7 @@ export const setUserResetPasswordToken = async ({ userId }: { userId: User['id']
       resetPasswordToken: resetToken,
       resetPasswordExpiration: resetExpiration,
     },
+    req: { transactionID },
   })
 
   return resetToken

--- a/src/mail/templates/AffiliateAccountSetup.ts
+++ b/src/mail/templates/AffiliateAccountSetup.ts
@@ -1,0 +1,68 @@
+export const affiliateAccountSetupEmailHtml = ({ setupLink }: { setupLink: string }) => {
+  return `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Welcome to OrcheStars Affiliate Program</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        line-height: 1.6;
+        color: #000;
+      }
+      .container {
+        max-width: 600px;
+        margin: 0 auto;
+        padding: 20px;
+      }
+      .content p {
+        margin-bottom: 12px;
+      }
+      strong {
+        font-weight: bold;
+      }
+      a {
+        color: #0a5cd9;
+        text-decoration: none;
+      }
+      a:hover {
+        text-decoration: underline;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <p><strong>Xin chào và chào mừng bạn đến với chương trình đối tác OrcheStars!</strong><br />
+      <em>Hello and welcome to the OrcheStars Affiliate Program!</em></p>
+
+      <p>
+        Tài khoản đối tác của bạn đã được tạo thành công. Để bắt đầu sử dụng, bạn cần thiết lập mật khẩu cho tài khoản của mình.<br />
+        <em>Your affiliate account has been successfully created. To get started, you need to set up a password for your account.</em>
+      </p>
+
+      <p>
+        Vui lòng nhấp vào liên kết sau để thiết lập mật khẩu của bạn: 
+        <a href="${setupLink}" target="_blank">THIẾT LẬP MẬT KHẨU</a>. Liên kết này sẽ hết hạn sau 1 giờ.<br />
+        <em>Please click on the following link to set up your password: 
+        <a href="${setupLink}" target="_blank">SET UP PASSWORD</a>. This link will expire in 1 hour.</em>
+      </p>
+
+      <p>
+        Sau khi thiết lập mật khẩu, bạn sẽ có thể truy cập vào bảng điều khiển đối tác để quản lý các liên kết và theo dõi hiệu suất của mình.<br />
+        <em>After setting up your password, you will be able to access the affiliate dashboard to manage your links and track your performance.</em>
+      </p>
+
+      <p>
+        Nếu bạn có bất kỳ câu hỏi nào, vui lòng liên hệ với đội ngũ hỗ trợ của chúng tôi.<br />
+        <em>If you have any questions, please contact our support team.</em>
+      </p>
+
+      <p>Trân trọng,<br />
+      <em>Best regards,</em></p>
+
+      <p>OrcheStars</p>
+    </div>
+  </body>
+</html>
+`
+}

--- a/src/types/TransactionID.ts
+++ b/src/types/TransactionID.ts
@@ -1,0 +1,1 @@
+export type TransactionID = number | Promise<number | string> | string


### PR DESCRIPTION
## ✨ Summary by Git AI

### 🔥 Changes
- Added a new hook to send an email to newly created affiliate users with a setup link.
- Implemented email sending and logging using existing utilities.
- Created a new email template for affiliate account setup.
- Introduced a TransactionID type for database operations.
- Modified email and user record creation to include transaction IDs for consistency.

## Summary by Sourcery

Trigger automatic affiliate setup emails on user creation by integrating a new hook, adding a dedicated email template, and ensuring transactional consistency with TransactionID handling.

New Features:
- Send affiliate account setup email to newly created affiliate users via a new afterChange hook
- Add an HTML email template for affiliate account setup with bilingual content

Enhancements:
- Propagate TransactionID through user and email payload operations for consistent logging
- Reuse the reset password token mechanism to generate affiliate setup links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Automatically sends a bilingual (Vietnamese and English) welcome email with password setup instructions to newly created affiliate users.
  - Added a dedicated affiliate account setup email template with a secure, time-limited setup link.

- **Enhancements**
  - Improved support for transaction tracking in email-related operations, enabling better association with specific processes.

- **Bug Fixes**
  - Ensured that errors during affiliate welcome email sending do not interrupt user creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->