### PR TITLE
feat: Add Management Affiliate to Collections in Admin Dashboard

### DIFF
--- a/src/components/AdminViews/Dashboard/Component.tsx
+++ b/src/components/AdminViews/Dashboard/Component.tsx
@@ -27,9 +27,25 @@ const Component = async ({
     entities: eventTicketEntities,
   }
 
+  const collections = navGroups.map((item) => {
+    if (item.label === 'Collections') {
+      const indexOfAffLinks = item.entities.findIndex((item) => item.slug === 'affiliate-links')
+      if (indexOfAffLinks !== -1) {
+        // Insert new item after index 1 (i.e., after a: '4')
+        item.entities.splice(indexOfAffLinks, 0, {
+          slug: 'affiliate',
+          type: '',
+          label: 'Management Affiliate',
+        })
+      }
+    }
+
+    return item
+  })
+
   return (
     <div>
-      <AdminCollections collections={[currentEventOnGoing, ...navGroups]} />
+      <AdminCollections collections={[currentEventOnGoing, ...collections]} />
     </div>
   )
 }


### PR DESCRIPTION
## ✨ Summary by Git AI

### 🔥 Changes
- Added a new 'Management Affiliate' entry under the 'Collections' nav group.
- This new entry is inserted before 'affiliate-links'.

## Summary by Sourcery

New Features:
- Add 'Management Affiliate' entry to the Collections navigation group in the Admin Dashboard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a "Management Affiliate" entry to the Collections section in the admin dashboard, positioned before "affiliate-links".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->