### PR TITLE
chore: comment out unused affiliate collections

### DIFF
--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -43,10 +43,10 @@ import { PromotionConfigs } from './collections/Promotion/PromotionConfigs'
 import { AffiliateLinks } from './collections/Affiliate/AffiliateLinks'
 import { AffiliateClickLogs } from './collections/Affiliate/AffiliateClickLogs'
 import { AffiliateSettings } from './collections/Affiliate/AffiliateSettings'
-import { AffiliateRanks } from './collections/Affiliate/AffiliateRanks'
-import { EventAffiliateRanks } from './collections/Affiliate/EventAffiliateRanks'
-import { AffiliateRankLogs } from './collections/Affiliate/AffiliateRankLogs'
-import { AffiliateUserProfiles } from './collections/Affiliate/AffiliateUserProfile'
+// import { AffiliateRanks } from './collections/Affiliate/AffiliateRanks'
+// import { EventAffiliateRanks } from './collections/Affiliate/EventAffiliateRanks'
+// import { AffiliateRankLogs } from './collections/Affiliate/AffiliateRankLogs'
+// import { AffiliateUserProfiles } from './collections/Affiliate/AffiliateUserProfile'
 // import { sendMailJob } from './collections/Emails/jobs/sendMail'
 
 const filename = fileURLToPath(import.meta.url)
@@ -149,10 +149,10 @@ export default buildConfig({
     FAQs,
     Admins,
     Emails,
-    AffiliateRanks,
-    EventAffiliateRanks,
-    AffiliateUserProfiles,
-    AffiliateRankLogs,
+    // AffiliateRanks,
+    // EventAffiliateRanks,
+    // AffiliateUserProfiles,
+    // AffiliateRankLogs,
     AffiliateLinks,
     AffiliateSettings,
     AffiliateClickLogs,


### PR DESCRIPTION
## ✨ Summary by Git AI

### 🔥 Changes
- Commented out unused AffiliateRanks, EventAffiliateRanks, AffiliateUserProfiles, and AffiliateRankLogs collections.
- This removes them from the build configuration.

## Summary by Sourcery

Chores:
- Comment out AffiliateRanks, EventAffiliateRanks, AffiliateRankLogs, and AffiliateUserProfiles imports and build entries