### PR TITLE
feat: hide affiliate ranks config on production

### DIFF
--- a/src/collections/Affiliate/helper/index.ts
+++ b/src/collections/Affiliate/helper/index.ts
@@ -1,0 +1,6 @@
+// temp, should be deleted in the future after full affiliate ranks applied on production
+const env = process.env.NEXT_PUBLIC_ENVIRONMENT
+
+export const HIDE_AFFILIATE_RANK_CONFIG = !env || env === 'production'
+
+console.log('HIDE_AFFILIATE_RANK_CONFIG', HIDE_AFFILIATE_RANK_CONFIG)

--- a/src/components/AdminViews/Dashboard/Component.tsx
+++ b/src/components/AdminViews/Dashboard/Component.tsx
@@ -29,7 +29,7 @@ const Component = async ({
 
   const collections = navGroups.map((item) => {
     if (item.label === 'Collections') {
-      const indexOfAffLinks = item.entities.findIndex((item) => item.slug === 'affiliate-ranks')
+      const indexOfAffLinks = item.entities.findIndex((item) => item.slug === 'affiliate-links')
       if (indexOfAffLinks !== -1) {
         // Insert new item after index 1 (i.e., after a: '4')
         item.entities.splice(indexOfAffLinks, 0, {

--- a/src/components/AdminViews/ManagementAffiliate/Page.client.tsx
+++ b/src/components/AdminViews/ManagementAffiliate/Page.client.tsx
@@ -19,6 +19,7 @@ import DashboardTab from './components/DashboardTab'
 import ManageAffiliateUserTab from './components/ManageAffiliateUserTab'
 import AffiliateClickLogsTab from './components/AffiliateClickLogsTab'
 import { AffiliateCollectionList } from './AffiliateCollectionList'
+import { HIDE_AFFILIATE_RANK_CONFIG } from '@/collections/Affiliate/helper'
 
 interface Props {
   affiliateUsers: User[]
@@ -54,11 +55,12 @@ const AffiliateManagementClient: React.FC<Props> = ({
             Manage affiliate users, track performance, and configure affiliate settings
           </p>
         </div>
-
-        <div style={{ marginBottom: 'calc(var(--base))' }}>
-          <h2 style={{ marginBottom: 'calc(var(--base))' }}>Affiliate Ranks</h2>
-          <AffiliateCollectionList />
-        </div>
+        {!HIDE_AFFILIATE_RANK_CONFIG && (
+          <div style={{ marginBottom: 'calc(var(--base))' }}>
+            <h2 style={{ marginBottom: 'calc(var(--base))' }}>Affiliate Ranks</h2>
+            <AffiliateCollectionList />
+          </div>
+        )}
 
         <PayloadTabs defaultValue="dashboard">
           <PayloadTabsList>

--- a/src/migrations/20250621_175024_create_affiliate_ranks.ts
+++ b/src/migrations/20250621_175024_create_affiliate_ranks.ts
@@ -1,278 +1,278 @@
 import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
 
 export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
-  await db.execute(sql`
-   CREATE TYPE "public"."enum_affiliate_ranks_rank_name" AS ENUM('seller', 'fan', 'ambassador', 'patron');
-  CREATE TYPE "public"."enum_event_affiliate_ranks_rank_name" AS ENUM('seller', 'fan', 'ambassador', 'patron');
-  CREATE TYPE "public"."enum_event_affiliate_ranks_status" AS ENUM('draft', 'active', 'disabled');
-  CREATE TYPE "public"."enum_affiliate_user_ranks_current_rank" AS ENUM('seller', 'fan', 'ambassador', 'patron');
-  CREATE TYPE "public"."enum_affiliate_user_ranks_pending_rank_upgrade" AS ENUM('seller', 'fan', 'ambassador', 'patron');
-  CREATE TYPE "public"."enum_affiliate_rank_logs_action_type" AS ENUM('add_points', 'subtract_points', 'rank_upgrade', 'rank_downgrade', 'confirm_rank_upgrade');
-  CREATE TYPE "public"."enum_affiliate_rank_logs_rank_before" AS ENUM('seller', 'fan', 'ambassador', 'patron');
-  CREATE TYPE "public"."enum_affiliate_rank_logs_rank_after" AS ENUM('seller', 'fan', 'ambassador', 'patron');
-  CREATE TABLE IF NOT EXISTS "affiliate_ranks_rewards_ticket_rewards" (
-  	"_order" integer NOT NULL,
-  	"_parent_id" integer NOT NULL,
-  	"id" varchar PRIMARY KEY NOT NULL,
-  	"min_tickets" numeric,
-  	"max_tickets" numeric,
-  	"min_revenue" numeric,
-  	"max_revenue" numeric,
-  	"reward_tickets" numeric
-  );
+  // await db.execute(sql`
+  //  CREATE TYPE "public"."enum_affiliate_ranks_rank_name" AS ENUM('seller', 'fan', 'ambassador', 'patron');
+  // CREATE TYPE "public"."enum_event_affiliate_ranks_rank_name" AS ENUM('seller', 'fan', 'ambassador', 'patron');
+  // CREATE TYPE "public"."enum_event_affiliate_ranks_status" AS ENUM('draft', 'active', 'disabled');
+  // CREATE TYPE "public"."enum_affiliate_user_ranks_current_rank" AS ENUM('seller', 'fan', 'ambassador', 'patron');
+  // CREATE TYPE "public"."enum_affiliate_user_ranks_pending_rank_upgrade" AS ENUM('seller', 'fan', 'ambassador', 'patron');
+  // CREATE TYPE "public"."enum_affiliate_rank_logs_action_type" AS ENUM('add_points', 'subtract_points', 'rank_upgrade', 'rank_downgrade', 'confirm_rank_upgrade');
+  // CREATE TYPE "public"."enum_affiliate_rank_logs_rank_before" AS ENUM('seller', 'fan', 'ambassador', 'patron');
+  // CREATE TYPE "public"."enum_affiliate_rank_logs_rank_after" AS ENUM('seller', 'fan', 'ambassador', 'patron');
+  // CREATE TABLE IF NOT EXISTS "affiliate_ranks_rewards_ticket_rewards" (
+  // 	"_order" integer NOT NULL,
+  // 	"_parent_id" integer NOT NULL,
+  // 	"id" varchar PRIMARY KEY NOT NULL,
+  // 	"min_tickets" numeric,
+  // 	"max_tickets" numeric,
+  // 	"min_revenue" numeric,
+  // 	"max_revenue" numeric,
+  // 	"reward_tickets" numeric
+  // );
   
-  CREATE TABLE IF NOT EXISTS "affiliate_ranks_rewards_commission_rewards" (
-  	"_order" integer NOT NULL,
-  	"_parent_id" integer NOT NULL,
-  	"id" varchar PRIMARY KEY NOT NULL,
-  	"min_tickets" numeric,
-  	"max_tickets" numeric,
-  	"min_revenue" numeric,
-  	"max_revenue" numeric,
-  	"commission_rate" numeric
-  );
+  // CREATE TABLE IF NOT EXISTS "affiliate_ranks_rewards_commission_rewards" (
+  // 	"_order" integer NOT NULL,
+  // 	"_parent_id" integer NOT NULL,
+  // 	"id" varchar PRIMARY KEY NOT NULL,
+  // 	"min_tickets" numeric,
+  // 	"max_tickets" numeric,
+  // 	"min_revenue" numeric,
+  // 	"max_revenue" numeric,
+  // 	"commission_rate" numeric
+  // );
   
-  CREATE TABLE IF NOT EXISTS "affiliate_ranks" (
-  	"id" serial PRIMARY KEY NOT NULL,
-  	"rank_name" "enum_affiliate_ranks_rank_name" NOT NULL,
-  	"description" varchar,
-  	"min_points" numeric DEFAULT 0 NOT NULL,
-  	"updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
-  	"created_at" timestamp(3) with time zone DEFAULT now() NOT NULL
-  );
+  // CREATE TABLE IF NOT EXISTS "affiliate_ranks" (
+  // 	"id" serial PRIMARY KEY NOT NULL,
+  // 	"rank_name" "enum_affiliate_ranks_rank_name" NOT NULL,
+  // 	"description" varchar,
+  // 	"min_points" numeric DEFAULT 0 NOT NULL,
+  // 	"updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  // 	"created_at" timestamp(3) with time zone DEFAULT now() NOT NULL
+  // );
   
-  CREATE TABLE IF NOT EXISTS "event_affiliate_ranks_event_rewards_ticket_rewards" (
-  	"_order" integer NOT NULL,
-  	"_parent_id" integer NOT NULL,
-  	"id" varchar PRIMARY KEY NOT NULL,
-  	"min_tickets" numeric,
-  	"max_tickets" numeric,
-  	"min_revenue" numeric,
-  	"max_revenue" numeric,
-  	"reward_tickets" numeric DEFAULT 0
-  );
+  // CREATE TABLE IF NOT EXISTS "event_affiliate_ranks_event_rewards_ticket_rewards" (
+  // 	"_order" integer NOT NULL,
+  // 	"_parent_id" integer NOT NULL,
+  // 	"id" varchar PRIMARY KEY NOT NULL,
+  // 	"min_tickets" numeric,
+  // 	"max_tickets" numeric,
+  // 	"min_revenue" numeric,
+  // 	"max_revenue" numeric,
+  // 	"reward_tickets" numeric DEFAULT 0
+  // );
   
-  CREATE TABLE IF NOT EXISTS "event_affiliate_ranks_event_rewards_commission_rewards" (
-  	"_order" integer NOT NULL,
-  	"_parent_id" integer NOT NULL,
-  	"id" varchar PRIMARY KEY NOT NULL,
-  	"min_tickets" numeric,
-  	"max_tickets" numeric,
-  	"min_revenue" numeric,
-  	"max_revenue" numeric,
-  	"commission_rate" numeric DEFAULT 0
-  );
+  // CREATE TABLE IF NOT EXISTS "event_affiliate_ranks_event_rewards_commission_rewards" (
+  // 	"_order" integer NOT NULL,
+  // 	"_parent_id" integer NOT NULL,
+  // 	"id" varchar PRIMARY KEY NOT NULL,
+  // 	"min_tickets" numeric,
+  // 	"max_tickets" numeric,
+  // 	"min_revenue" numeric,
+  // 	"max_revenue" numeric,
+  // 	"commission_rate" numeric DEFAULT 0
+  // );
   
-  CREATE TABLE IF NOT EXISTS "event_affiliate_ranks" (
-  	"id" serial PRIMARY KEY NOT NULL,
-  	"event_id" integer NOT NULL,
-  	"affiliate_user_id" integer NOT NULL,
-  	"rank_name" "enum_event_affiliate_ranks_rank_name" NOT NULL,
-  	"status" "enum_event_affiliate_ranks_status" DEFAULT 'draft' NOT NULL,
-  	"is_locked" boolean DEFAULT true,
-  	"updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
-  	"created_at" timestamp(3) with time zone DEFAULT now() NOT NULL
-  );
+  // CREATE TABLE IF NOT EXISTS "event_affiliate_ranks" (
+  // 	"id" serial PRIMARY KEY NOT NULL,
+  // 	"event_id" integer NOT NULL,
+  // 	"affiliate_user_id" integer NOT NULL,
+  // 	"rank_name" "enum_event_affiliate_ranks_rank_name" NOT NULL,
+  // 	"status" "enum_event_affiliate_ranks_status" DEFAULT 'draft' NOT NULL,
+  // 	"is_locked" boolean DEFAULT true,
+  // 	"updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  // 	"created_at" timestamp(3) with time zone DEFAULT now() NOT NULL
+  // );
   
-  CREATE TABLE IF NOT EXISTS "affiliate_user_ranks" (
-  	"id" serial PRIMARY KEY NOT NULL,
-  	"affiliate_user_id" integer NOT NULL,
-  	"current_rank" "enum_affiliate_user_ranks_current_rank" DEFAULT 'seller' NOT NULL,
-  	"total_points" numeric DEFAULT 0 NOT NULL,
-  	"total_revenue" numeric DEFAULT 0 NOT NULL,
-  	"total_revenue_before_discount" numeric DEFAULT 0 NOT NULL,
-  	"total_tickets_sold" numeric DEFAULT 0 NOT NULL,
-  	"total_commission_earned" numeric DEFAULT 0 NOT NULL,
-  	"total_tickets_rewarded" numeric DEFAULT 0 NOT NULL,
-  	"rank_achieved_date" timestamp(3) with time zone,
-  	"last_activity_date" timestamp(3) with time zone,
-  	"pending_rank_upgrade" "enum_affiliate_user_ranks_pending_rank_upgrade",
-  	"updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
-  	"created_at" timestamp(3) with time zone DEFAULT now() NOT NULL
-  );
+  // CREATE TABLE IF NOT EXISTS "affiliate_user_ranks" (
+  // 	"id" serial PRIMARY KEY NOT NULL,
+  // 	"affiliate_user_id" integer NOT NULL,
+  // 	"current_rank" "enum_affiliate_user_ranks_current_rank" DEFAULT 'seller' NOT NULL,
+  // 	"total_points" numeric DEFAULT 0 NOT NULL,
+  // 	"total_revenue" numeric DEFAULT 0 NOT NULL,
+  // 	"total_revenue_before_discount" numeric DEFAULT 0 NOT NULL,
+  // 	"total_tickets_sold" numeric DEFAULT 0 NOT NULL,
+  // 	"total_commission_earned" numeric DEFAULT 0 NOT NULL,
+  // 	"total_tickets_rewarded" numeric DEFAULT 0 NOT NULL,
+  // 	"rank_achieved_date" timestamp(3) with time zone,
+  // 	"last_activity_date" timestamp(3) with time zone,
+  // 	"pending_rank_upgrade" "enum_affiliate_user_ranks_pending_rank_upgrade",
+  // 	"updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  // 	"created_at" timestamp(3) with time zone DEFAULT now() NOT NULL
+  // );
   
-  CREATE TABLE IF NOT EXISTS "affiliate_rank_logs" (
-  	"id" serial PRIMARY KEY NOT NULL,
-  	"affiliate_user_id" integer NOT NULL,
-  	"action_type" "enum_affiliate_rank_logs_action_type" NOT NULL,
-  	"points_change" numeric DEFAULT 0,
-  	"points_before" numeric,
-  	"points_after" numeric,
-  	"rank_before" "enum_affiliate_rank_logs_rank_before",
-  	"rank_after" "enum_affiliate_rank_logs_rank_after",
-  	"description" varchar,
-  	"occurred_at" timestamp(3) with time zone NOT NULL,
-  	"event_id" integer,
-  	"order_id" integer,
-  	"admin_user_id" integer,
-  	"updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
-  	"created_at" timestamp(3) with time zone DEFAULT now() NOT NULL
-  );
+  // CREATE TABLE IF NOT EXISTS "affiliate_rank_logs" (
+  // 	"id" serial PRIMARY KEY NOT NULL,
+  // 	"affiliate_user_id" integer NOT NULL,
+  // 	"action_type" "enum_affiliate_rank_logs_action_type" NOT NULL,
+  // 	"points_change" numeric DEFAULT 0,
+  // 	"points_before" numeric,
+  // 	"points_after" numeric,
+  // 	"rank_before" "enum_affiliate_rank_logs_rank_before",
+  // 	"rank_after" "enum_affiliate_rank_logs_rank_after",
+  // 	"description" varchar,
+  // 	"occurred_at" timestamp(3) with time zone NOT NULL,
+  // 	"event_id" integer,
+  // 	"order_id" integer,
+  // 	"admin_user_id" integer,
+  // 	"updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  // 	"created_at" timestamp(3) with time zone DEFAULT now() NOT NULL
+  // );
   
-  ALTER TABLE "payload_locked_documents_rels" ADD COLUMN "affiliate_ranks_id" integer;
-  ALTER TABLE "payload_locked_documents_rels" ADD COLUMN "event_affiliate_ranks_id" integer;
-  ALTER TABLE "payload_locked_documents_rels" ADD COLUMN "affiliate_user_ranks_id" integer;
-  ALTER TABLE "payload_locked_documents_rels" ADD COLUMN "affiliate_rank_logs_id" integer;
-  DO $$ BEGIN
-   ALTER TABLE "affiliate_ranks_rewards_ticket_rewards" ADD CONSTRAINT "affiliate_ranks_rewards_ticket_rewards_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."affiliate_ranks"("id") ON DELETE cascade ON UPDATE no action;
-  EXCEPTION
-   WHEN duplicate_object THEN null;
-  END $$;
+  // ALTER TABLE "payload_locked_documents_rels" ADD COLUMN "affiliate_ranks_id" integer;
+  // ALTER TABLE "payload_locked_documents_rels" ADD COLUMN "event_affiliate_ranks_id" integer;
+  // ALTER TABLE "payload_locked_documents_rels" ADD COLUMN "affiliate_user_ranks_id" integer;
+  // ALTER TABLE "payload_locked_documents_rels" ADD COLUMN "affiliate_rank_logs_id" integer;
+  // DO $$ BEGIN
+  //  ALTER TABLE "affiliate_ranks_rewards_ticket_rewards" ADD CONSTRAINT "affiliate_ranks_rewards_ticket_rewards_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."affiliate_ranks"("id") ON DELETE cascade ON UPDATE no action;
+  // EXCEPTION
+  //  WHEN duplicate_object THEN null;
+  // END $$;
   
-  DO $$ BEGIN
-   ALTER TABLE "affiliate_ranks_rewards_commission_rewards" ADD CONSTRAINT "affiliate_ranks_rewards_commission_rewards_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."affiliate_ranks"("id") ON DELETE cascade ON UPDATE no action;
-  EXCEPTION
-   WHEN duplicate_object THEN null;
-  END $$;
+  // DO $$ BEGIN
+  //  ALTER TABLE "affiliate_ranks_rewards_commission_rewards" ADD CONSTRAINT "affiliate_ranks_rewards_commission_rewards_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."affiliate_ranks"("id") ON DELETE cascade ON UPDATE no action;
+  // EXCEPTION
+  //  WHEN duplicate_object THEN null;
+  // END $$;
   
-  DO $$ BEGIN
-   ALTER TABLE "event_affiliate_ranks_event_rewards_ticket_rewards" ADD CONSTRAINT "event_affiliate_ranks_event_rewards_ticket_rewards_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."event_affiliate_ranks"("id") ON DELETE cascade ON UPDATE no action;
-  EXCEPTION
-   WHEN duplicate_object THEN null;
-  END $$;
+  // DO $$ BEGIN
+  //  ALTER TABLE "event_affiliate_ranks_event_rewards_ticket_rewards" ADD CONSTRAINT "event_affiliate_ranks_event_rewards_ticket_rewards_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."event_affiliate_ranks"("id") ON DELETE cascade ON UPDATE no action;
+  // EXCEPTION
+  //  WHEN duplicate_object THEN null;
+  // END $$;
   
-  DO $$ BEGIN
-   ALTER TABLE "event_affiliate_ranks_event_rewards_commission_rewards" ADD CONSTRAINT "event_affiliate_ranks_event_rewards_commission_rewards_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."event_affiliate_ranks"("id") ON DELETE cascade ON UPDATE no action;
-  EXCEPTION
-   WHEN duplicate_object THEN null;
-  END $$;
+  // DO $$ BEGIN
+  //  ALTER TABLE "event_affiliate_ranks_event_rewards_commission_rewards" ADD CONSTRAINT "event_affiliate_ranks_event_rewards_commission_rewards_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."event_affiliate_ranks"("id") ON DELETE cascade ON UPDATE no action;
+  // EXCEPTION
+  //  WHEN duplicate_object THEN null;
+  // END $$;
   
-  DO $$ BEGIN
-   ALTER TABLE "event_affiliate_ranks" ADD CONSTRAINT "event_affiliate_ranks_event_id_events_id_fk" FOREIGN KEY ("event_id") REFERENCES "public"."events"("id") ON DELETE set null ON UPDATE no action;
-  EXCEPTION
-   WHEN duplicate_object THEN null;
-  END $$;
+  // DO $$ BEGIN
+  //  ALTER TABLE "event_affiliate_ranks" ADD CONSTRAINT "event_affiliate_ranks_event_id_events_id_fk" FOREIGN KEY ("event_id") REFERENCES "public"."events"("id") ON DELETE set null ON UPDATE no action;
+  // EXCEPTION
+  //  WHEN duplicate_object THEN null;
+  // END $$;
   
-  DO $$ BEGIN
-   ALTER TABLE "event_affiliate_ranks" ADD CONSTRAINT "event_affiliate_ranks_affiliate_user_id_users_id_fk" FOREIGN KEY ("affiliate_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;
-  EXCEPTION
-   WHEN duplicate_object THEN null;
-  END $$;
+  // DO $$ BEGIN
+  //  ALTER TABLE "event_affiliate_ranks" ADD CONSTRAINT "event_affiliate_ranks_affiliate_user_id_users_id_fk" FOREIGN KEY ("affiliate_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;
+  // EXCEPTION
+  //  WHEN duplicate_object THEN null;
+  // END $$;
   
-  DO $$ BEGIN
-   ALTER TABLE "affiliate_user_ranks" ADD CONSTRAINT "affiliate_user_ranks_affiliate_user_id_users_id_fk" FOREIGN KEY ("affiliate_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;
-  EXCEPTION
-   WHEN duplicate_object THEN null;
-  END $$;
+  // DO $$ BEGIN
+  //  ALTER TABLE "affiliate_user_ranks" ADD CONSTRAINT "affiliate_user_ranks_affiliate_user_id_users_id_fk" FOREIGN KEY ("affiliate_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;
+  // EXCEPTION
+  //  WHEN duplicate_object THEN null;
+  // END $$;
   
-  DO $$ BEGIN
-   ALTER TABLE "affiliate_rank_logs" ADD CONSTRAINT "affiliate_rank_logs_affiliate_user_id_users_id_fk" FOREIGN KEY ("affiliate_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;
-  EXCEPTION
-   WHEN duplicate_object THEN null;
-  END $$;
+  // DO $$ BEGIN
+  //  ALTER TABLE "affiliate_rank_logs" ADD CONSTRAINT "affiliate_rank_logs_affiliate_user_id_users_id_fk" FOREIGN KEY ("affiliate_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;
+  // EXCEPTION
+  //  WHEN duplicate_object THEN null;
+  // END $$;
   
-  DO $$ BEGIN
-   ALTER TABLE "affiliate_rank_logs" ADD CONSTRAINT "affiliate_rank_logs_event_id_events_id_fk" FOREIGN KEY ("event_id") REFERENCES "public"."events"("id") ON DELETE set null ON UPDATE no action;
-  EXCEPTION
-   WHEN duplicate_object THEN null;
-  END $$;
+  // DO $$ BEGIN
+  //  ALTER TABLE "affiliate_rank_logs" ADD CONSTRAINT "affiliate_rank_logs_event_id_events_id_fk" FOREIGN KEY ("event_id") REFERENCES "public"."events"("id") ON DELETE set null ON UPDATE no action;
+  // EXCEPTION
+  //  WHEN duplicate_object THEN null;
+  // END $$;
   
-  DO $$ BEGIN
-   ALTER TABLE "affiliate_rank_logs" ADD CONSTRAINT "affiliate_rank_logs_order_id_orders_id_fk" FOREIGN KEY ("order_id") REFERENCES "public"."orders"("id") ON DELETE set null ON UPDATE no action;
-  EXCEPTION
-   WHEN duplicate_object THEN null;
-  END $$;
+  // DO $$ BEGIN
+  //  ALTER TABLE "affiliate_rank_logs" ADD CONSTRAINT "affiliate_rank_logs_order_id_orders_id_fk" FOREIGN KEY ("order_id") REFERENCES "public"."orders"("id") ON DELETE set null ON UPDATE no action;
+  // EXCEPTION
+  //  WHEN duplicate_object THEN null;
+  // END $$;
   
-  DO $$ BEGIN
-   ALTER TABLE "affiliate_rank_logs" ADD CONSTRAINT "affiliate_rank_logs_admin_user_id_admins_id_fk" FOREIGN KEY ("admin_user_id") REFERENCES "public"."admins"("id") ON DELETE set null ON UPDATE no action;
-  EXCEPTION
-   WHEN duplicate_object THEN null;
-  END $$;
+  // DO $$ BEGIN
+  //  ALTER TABLE "affiliate_rank_logs" ADD CONSTRAINT "affiliate_rank_logs_admin_user_id_admins_id_fk" FOREIGN KEY ("admin_user_id") REFERENCES "public"."admins"("id") ON DELETE set null ON UPDATE no action;
+  // EXCEPTION
+  //  WHEN duplicate_object THEN null;
+  // END $$;
   
-  CREATE INDEX IF NOT EXISTS "affiliate_ranks_rewards_ticket_rewards_order_idx" ON "affiliate_ranks_rewards_ticket_rewards" USING btree ("_order");
-  CREATE INDEX IF NOT EXISTS "affiliate_ranks_rewards_ticket_rewards_parent_id_idx" ON "affiliate_ranks_rewards_ticket_rewards" USING btree ("_parent_id");
-  CREATE INDEX IF NOT EXISTS "affiliate_ranks_rewards_commission_rewards_order_idx" ON "affiliate_ranks_rewards_commission_rewards" USING btree ("_order");
-  CREATE INDEX IF NOT EXISTS "affiliate_ranks_rewards_commission_rewards_parent_id_idx" ON "affiliate_ranks_rewards_commission_rewards" USING btree ("_parent_id");
-  CREATE UNIQUE INDEX IF NOT EXISTS "affiliate_ranks_rank_name_idx" ON "affiliate_ranks" USING btree ("rank_name");
-  CREATE INDEX IF NOT EXISTS "affiliate_ranks_updated_at_idx" ON "affiliate_ranks" USING btree ("updated_at");
-  CREATE INDEX IF NOT EXISTS "affiliate_ranks_created_at_idx" ON "affiliate_ranks" USING btree ("created_at");
-  CREATE INDEX IF NOT EXISTS "event_affiliate_ranks_event_rewards_ticket_rewards_order_idx" ON "event_affiliate_ranks_event_rewards_ticket_rewards" USING btree ("_order");
-  CREATE INDEX IF NOT EXISTS "event_affiliate_ranks_event_rewards_ticket_rewards_parent_id_idx" ON "event_affiliate_ranks_event_rewards_ticket_rewards" USING btree ("_parent_id");
-  CREATE INDEX IF NOT EXISTS "event_affiliate_ranks_event_rewards_commission_rewards_order_idx" ON "event_affiliate_ranks_event_rewards_commission_rewards" USING btree ("_order");
-  CREATE INDEX IF NOT EXISTS "event_affiliate_ranks_event_rewards_commission_rewards_parent_id_idx" ON "event_affiliate_ranks_event_rewards_commission_rewards" USING btree ("_parent_id");
-  CREATE INDEX IF NOT EXISTS "event_affiliate_ranks_event_idx" ON "event_affiliate_ranks" USING btree ("event_id");
-  CREATE INDEX IF NOT EXISTS "event_affiliate_ranks_affiliate_user_idx" ON "event_affiliate_ranks" USING btree ("affiliate_user_id");
-  CREATE INDEX IF NOT EXISTS "event_affiliate_ranks_updated_at_idx" ON "event_affiliate_ranks" USING btree ("updated_at");
-  CREATE INDEX IF NOT EXISTS "event_affiliate_ranks_created_at_idx" ON "event_affiliate_ranks" USING btree ("created_at");
-  CREATE UNIQUE INDEX IF NOT EXISTS "affiliate_user_ranks_affiliate_user_idx" ON "affiliate_user_ranks" USING btree ("affiliate_user_id");
-  CREATE INDEX IF NOT EXISTS "affiliate_user_ranks_updated_at_idx" ON "affiliate_user_ranks" USING btree ("updated_at");
-  CREATE INDEX IF NOT EXISTS "affiliate_user_ranks_created_at_idx" ON "affiliate_user_ranks" USING btree ("created_at");
-  CREATE INDEX IF NOT EXISTS "affiliate_rank_logs_affiliate_user_idx" ON "affiliate_rank_logs" USING btree ("affiliate_user_id");
-  CREATE INDEX IF NOT EXISTS "affiliate_rank_logs_event_idx" ON "affiliate_rank_logs" USING btree ("event_id");
-  CREATE INDEX IF NOT EXISTS "affiliate_rank_logs_order_idx" ON "affiliate_rank_logs" USING btree ("order_id");
-  CREATE INDEX IF NOT EXISTS "affiliate_rank_logs_admin_user_idx" ON "affiliate_rank_logs" USING btree ("admin_user_id");
-  CREATE INDEX IF NOT EXISTS "affiliate_rank_logs_updated_at_idx" ON "affiliate_rank_logs" USING btree ("updated_at");
-  CREATE INDEX IF NOT EXISTS "affiliate_rank_logs_created_at_idx" ON "affiliate_rank_logs" USING btree ("created_at");
-  DO $$ BEGIN
-   ALTER TABLE "payload_locked_documents_rels" ADD CONSTRAINT "payload_locked_documents_rels_affiliate_ranks_fk" FOREIGN KEY ("affiliate_ranks_id") REFERENCES "public"."affiliate_ranks"("id") ON DELETE cascade ON UPDATE no action;
-  EXCEPTION
-   WHEN duplicate_object THEN null;
-  END $$;
+  // CREATE INDEX IF NOT EXISTS "affiliate_ranks_rewards_ticket_rewards_order_idx" ON "affiliate_ranks_rewards_ticket_rewards" USING btree ("_order");
+  // CREATE INDEX IF NOT EXISTS "affiliate_ranks_rewards_ticket_rewards_parent_id_idx" ON "affiliate_ranks_rewards_ticket_rewards" USING btree ("_parent_id");
+  // CREATE INDEX IF NOT EXISTS "affiliate_ranks_rewards_commission_rewards_order_idx" ON "affiliate_ranks_rewards_commission_rewards" USING btree ("_order");
+  // CREATE INDEX IF NOT EXISTS "affiliate_ranks_rewards_commission_rewards_parent_id_idx" ON "affiliate_ranks_rewards_commission_rewards" USING btree ("_parent_id");
+  // CREATE UNIQUE INDEX IF NOT EXISTS "affiliate_ranks_rank_name_idx" ON "affiliate_ranks" USING btree ("rank_name");
+  // CREATE INDEX IF NOT EXISTS "affiliate_ranks_updated_at_idx" ON "affiliate_ranks" USING btree ("updated_at");
+  // CREATE INDEX IF NOT EXISTS "affiliate_ranks_created_at_idx" ON "affiliate_ranks" USING btree ("created_at");
+  // CREATE INDEX IF NOT EXISTS "event_affiliate_ranks_event_rewards_ticket_rewards_order_idx" ON "event_affiliate_ranks_event_rewards_ticket_rewards" USING btree ("_order");
+  // CREATE INDEX IF NOT EXISTS "event_affiliate_ranks_event_rewards_ticket_rewards_parent_id_idx" ON "event_affiliate_ranks_event_rewards_ticket_rewards" USING btree ("_parent_id");
+  // CREATE INDEX IF NOT EXISTS "event_affiliate_ranks_event_rewards_commission_rewards_order_idx" ON "event_affiliate_ranks_event_rewards_commission_rewards" USING btree ("_order");
+  // CREATE INDEX IF NOT EXISTS "event_affiliate_ranks_event_rewards_commission_rewards_parent_id_idx" ON "event_affiliate_ranks_event_rewards_commission_rewards" USING btree ("_parent_id");
+  // CREATE INDEX IF NOT EXISTS "event_affiliate_ranks_event_idx" ON "event_affiliate_ranks" USING btree ("event_id");
+  // CREATE INDEX IF NOT EXISTS "event_affiliate_ranks_affiliate_user_idx" ON "event_affiliate_ranks" USING btree ("affiliate_user_id");
+  // CREATE INDEX IF NOT EXISTS "event_affiliate_ranks_updated_at_idx" ON "event_affiliate_ranks" USING btree ("updated_at");
+  // CREATE INDEX IF NOT EXISTS "event_affiliate_ranks_created_at_idx" ON "event_affiliate_ranks" USING btree ("created_at");
+  // CREATE UNIQUE INDEX IF NOT EXISTS "affiliate_user_ranks_affiliate_user_idx" ON "affiliate_user_ranks" USING btree ("affiliate_user_id");
+  // CREATE INDEX IF NOT EXISTS "affiliate_user_ranks_updated_at_idx" ON "affiliate_user_ranks" USING btree ("updated_at");
+  // CREATE INDEX IF NOT EXISTS "affiliate_user_ranks_created_at_idx" ON "affiliate_user_ranks" USING btree ("created_at");
+  // CREATE INDEX IF NOT EXISTS "affiliate_rank_logs_affiliate_user_idx" ON "affiliate_rank_logs" USING btree ("affiliate_user_id");
+  // CREATE INDEX IF NOT EXISTS "affiliate_rank_logs_event_idx" ON "affiliate_rank_logs" USING btree ("event_id");
+  // CREATE INDEX IF NOT EXISTS "affiliate_rank_logs_order_idx" ON "affiliate_rank_logs" USING btree ("order_id");
+  // CREATE INDEX IF NOT EXISTS "affiliate_rank_logs_admin_user_idx" ON "affiliate_rank_logs" USING btree ("admin_user_id");
+  // CREATE INDEX IF NOT EXISTS "affiliate_rank_logs_updated_at_idx" ON "affiliate_rank_logs" USING btree ("updated_at");
+  // CREATE INDEX IF NOT EXISTS "affiliate_rank_logs_created_at_idx" ON "affiliate_rank_logs" USING btree ("created_at");
+  // DO $$ BEGIN
+  //  ALTER TABLE "payload_locked_documents_rels" ADD CONSTRAINT "payload_locked_documents_rels_affiliate_ranks_fk" FOREIGN KEY ("affiliate_ranks_id") REFERENCES "public"."affiliate_ranks"("id") ON DELETE cascade ON UPDATE no action;
+  // EXCEPTION
+  //  WHEN duplicate_object THEN null;
+  // END $$;
   
-  DO $$ BEGIN
-   ALTER TABLE "payload_locked_documents_rels" ADD CONSTRAINT "payload_locked_documents_rels_event_affiliate_ranks_fk" FOREIGN KEY ("event_affiliate_ranks_id") REFERENCES "public"."event_affiliate_ranks"("id") ON DELETE cascade ON UPDATE no action;
-  EXCEPTION
-   WHEN duplicate_object THEN null;
-  END $$;
+  // DO $$ BEGIN
+  //  ALTER TABLE "payload_locked_documents_rels" ADD CONSTRAINT "payload_locked_documents_rels_event_affiliate_ranks_fk" FOREIGN KEY ("event_affiliate_ranks_id") REFERENCES "public"."event_affiliate_ranks"("id") ON DELETE cascade ON UPDATE no action;
+  // EXCEPTION
+  //  WHEN duplicate_object THEN null;
+  // END $$;
   
-  DO $$ BEGIN
-   ALTER TABLE "payload_locked_documents_rels" ADD CONSTRAINT "payload_locked_documents_rels_affiliate_user_ranks_fk" FOREIGN KEY ("affiliate_user_ranks_id") REFERENCES "public"."affiliate_user_ranks"("id") ON DELETE cascade ON UPDATE no action;
-  EXCEPTION
-   WHEN duplicate_object THEN null;
-  END $$;
+  // DO $$ BEGIN
+  //  ALTER TABLE "payload_locked_documents_rels" ADD CONSTRAINT "payload_locked_documents_rels_affiliate_user_ranks_fk" FOREIGN KEY ("affiliate_user_ranks_id") REFERENCES "public"."affiliate_user_ranks"("id") ON DELETE cascade ON UPDATE no action;
+  // EXCEPTION
+  //  WHEN duplicate_object THEN null;
+  // END $$;
   
-  DO $$ BEGIN
-   ALTER TABLE "payload_locked_documents_rels" ADD CONSTRAINT "payload_locked_documents_rels_affiliate_rank_logs_fk" FOREIGN KEY ("affiliate_rank_logs_id") REFERENCES "public"."affiliate_rank_logs"("id") ON DELETE cascade ON UPDATE no action;
-  EXCEPTION
-   WHEN duplicate_object THEN null;
-  END $$;
+  // DO $$ BEGIN
+  //  ALTER TABLE "payload_locked_documents_rels" ADD CONSTRAINT "payload_locked_documents_rels_affiliate_rank_logs_fk" FOREIGN KEY ("affiliate_rank_logs_id") REFERENCES "public"."affiliate_rank_logs"("id") ON DELETE cascade ON UPDATE no action;
+  // EXCEPTION
+  //  WHEN duplicate_object THEN null;
+  // END $$;
   
-  CREATE INDEX IF NOT EXISTS "payload_locked_documents_rels_affiliate_ranks_id_idx" ON "payload_locked_documents_rels" USING btree ("affiliate_ranks_id");
-  CREATE INDEX IF NOT EXISTS "payload_locked_documents_rels_event_affiliate_ranks_id_idx" ON "payload_locked_documents_rels" USING btree ("event_affiliate_ranks_id");
-  CREATE INDEX IF NOT EXISTS "payload_locked_documents_rels_affiliate_user_ranks_id_idx" ON "payload_locked_documents_rels" USING btree ("affiliate_user_ranks_id");
-  CREATE INDEX IF NOT EXISTS "payload_locked_documents_rels_affiliate_rank_logs_id_idx" ON "payload_locked_documents_rels" USING btree ("affiliate_rank_logs_id");`)
+  // CREATE INDEX IF NOT EXISTS "payload_locked_documents_rels_affiliate_ranks_id_idx" ON "payload_locked_documents_rels" USING btree ("affiliate_ranks_id");
+  // CREATE INDEX IF NOT EXISTS "payload_locked_documents_rels_event_affiliate_ranks_id_idx" ON "payload_locked_documents_rels" USING btree ("event_affiliate_ranks_id");
+  // CREATE INDEX IF NOT EXISTS "payload_locked_documents_rels_affiliate_user_ranks_id_idx" ON "payload_locked_documents_rels" USING btree ("affiliate_user_ranks_id");
+  // CREATE INDEX IF NOT EXISTS "payload_locked_documents_rels_affiliate_rank_logs_id_idx" ON "payload_locked_documents_rels" USING btree ("affiliate_rank_logs_id");`)
 }
 
 export async function down({ db, payload, req }: MigrateDownArgs): Promise<void> {
-  await db.execute(sql`
-   ALTER TABLE "affiliate_ranks_rewards_ticket_rewards" DISABLE ROW LEVEL SECURITY;
-  ALTER TABLE "affiliate_ranks_rewards_commission_rewards" DISABLE ROW LEVEL SECURITY;
-  ALTER TABLE "affiliate_ranks" DISABLE ROW LEVEL SECURITY;
-  ALTER TABLE "event_affiliate_ranks_event_rewards_ticket_rewards" DISABLE ROW LEVEL SECURITY;
-  ALTER TABLE "event_affiliate_ranks_event_rewards_commission_rewards" DISABLE ROW LEVEL SECURITY;
-  ALTER TABLE "event_affiliate_ranks" DISABLE ROW LEVEL SECURITY;
-  ALTER TABLE "affiliate_user_ranks" DISABLE ROW LEVEL SECURITY;
-  ALTER TABLE "affiliate_rank_logs" DISABLE ROW LEVEL SECURITY;
-  DROP TABLE "affiliate_ranks_rewards_ticket_rewards" CASCADE;
-  DROP TABLE "affiliate_ranks_rewards_commission_rewards" CASCADE;
-  DROP TABLE "affiliate_ranks" CASCADE;
-  DROP TABLE "event_affiliate_ranks_event_rewards_ticket_rewards" CASCADE;
-  DROP TABLE "event_affiliate_ranks_event_rewards_commission_rewards" CASCADE;
-  DROP TABLE "event_affiliate_ranks" CASCADE;
-  DROP TABLE "affiliate_user_ranks" CASCADE;
-  DROP TABLE "affiliate_rank_logs" CASCADE;
-  ALTER TABLE "payload_locked_documents_rels" DROP CONSTRAINT "payload_locked_documents_rels_affiliate_ranks_fk";
+  // await db.execute(sql`
+  //  ALTER TABLE "affiliate_ranks_rewards_ticket_rewards" DISABLE ROW LEVEL SECURITY;
+  // ALTER TABLE "affiliate_ranks_rewards_commission_rewards" DISABLE ROW LEVEL SECURITY;
+  // ALTER TABLE "affiliate_ranks" DISABLE ROW LEVEL SECURITY;
+  // ALTER TABLE "event_affiliate_ranks_event_rewards_ticket_rewards" DISABLE ROW LEVEL SECURITY;
+  // ALTER TABLE "event_affiliate_ranks_event_rewards_commission_rewards" DISABLE ROW LEVEL SECURITY;
+  // ALTER TABLE "event_affiliate_ranks" DISABLE ROW LEVEL SECURITY;
+  // ALTER TABLE "affiliate_user_ranks" DISABLE ROW LEVEL SECURITY;
+  // ALTER TABLE "affiliate_rank_logs" DISABLE ROW LEVEL SECURITY;
+  // DROP TABLE "affiliate_ranks_rewards_ticket_rewards" CASCADE;
+  // DROP TABLE "affiliate_ranks_rewards_commission_rewards" CASCADE;
+  // DROP TABLE "affiliate_ranks" CASCADE;
+  // DROP TABLE "event_affiliate_ranks_event_rewards_ticket_rewards" CASCADE;
+  // DROP TABLE "event_affiliate_ranks_event_rewards_commission_rewards" CASCADE;
+  // DROP TABLE "event_affiliate_ranks" CASCADE;
+  // DROP TABLE "affiliate_user_ranks" CASCADE;
+  // DROP TABLE "affiliate_rank_logs" CASCADE;
+  // ALTER TABLE "payload_locked_documents_rels" DROP CONSTRAINT "payload_locked_documents_rels_affiliate_ranks_fk";
   
-  ALTER TABLE "payload_locked_documents_rels" DROP CONSTRAINT "payload_locked_documents_rels_event_affiliate_ranks_fk";
+  // ALTER TABLE "payload_locked_documents_rels" DROP CONSTRAINT "payload_locked_documents_rels_event_affiliate_ranks_fk";
   
-  ALTER TABLE "payload_locked_documents_rels" DROP CONSTRAINT "payload_locked_documents_rels_affiliate_user_ranks_fk";
+  // ALTER TABLE "payload_locked_documents_rels" DROP CONSTRAINT "payload_locked_documents_rels_affiliate_user_ranks_fk";
   
-  ALTER TABLE "payload_locked_documents_rels" DROP CONSTRAINT "payload_locked_documents_rels_affiliate_rank_logs_fk";
+  // ALTER TABLE "payload_locked_documents_rels" DROP CONSTRAINT "payload_locked_documents_rels_affiliate_rank_logs_fk";
   
-  DROP INDEX IF EXISTS "payload_locked_documents_rels_affiliate_ranks_id_idx";
-  DROP INDEX IF EXISTS "payload_locked_documents_rels_event_affiliate_ranks_id_idx";
-  DROP INDEX IF EXISTS "payload_locked_documents_rels_affiliate_user_ranks_id_idx";
-  DROP INDEX IF EXISTS "payload_locked_documents_rels_affiliate_rank_logs_id_idx";
-  ALTER TABLE "payload_locked_documents_rels" DROP COLUMN IF EXISTS "affiliate_ranks_id";
-  ALTER TABLE "payload_locked_documents_rels" DROP COLUMN IF EXISTS "event_affiliate_ranks_id";
-  ALTER TABLE "payload_locked_documents_rels" DROP COLUMN IF EXISTS "affiliate_user_ranks_id";
-  ALTER TABLE "payload_locked_documents_rels" DROP COLUMN IF EXISTS "affiliate_rank_logs_id";
-  DROP TYPE "public"."enum_affiliate_ranks_rank_name";
-  DROP TYPE "public"."enum_event_affiliate_ranks_rank_name";
-  DROP TYPE "public"."enum_event_affiliate_ranks_status";
-  DROP TYPE "public"."enum_affiliate_user_ranks_current_rank";
-  DROP TYPE "public"."enum_affiliate_user_ranks_pending_rank_upgrade";
-  DROP TYPE "public"."enum_affiliate_rank_logs_action_type";
-  DROP TYPE "public"."enum_affiliate_rank_logs_rank_before";
-  DROP TYPE "public"."enum_affiliate_rank_logs_rank_after";`)
+  // DROP INDEX IF EXISTS "payload_locked_documents_rels_affiliate_ranks_id_idx";
+  // DROP INDEX IF EXISTS "payload_locked_documents_rels_event_affiliate_ranks_id_idx";
+  // DROP INDEX IF EXISTS "payload_locked_documents_rels_affiliate_user_ranks_id_idx";
+  // DROP INDEX IF EXISTS "payload_locked_documents_rels_affiliate_rank_logs_id_idx";
+  // ALTER TABLE "payload_locked_documents_rels" DROP COLUMN IF EXISTS "affiliate_ranks_id";
+  // ALTER TABLE "payload_locked_documents_rels" DROP COLUMN IF EXISTS "event_affiliate_ranks_id";
+  // ALTER TABLE "payload_locked_documents_rels" DROP COLUMN IF EXISTS "affiliate_user_ranks_id";
+  // ALTER TABLE "payload_locked_documents_rels" DROP COLUMN IF EXISTS "affiliate_rank_logs_id";
+  // DROP TYPE "public"."enum_affiliate_ranks_rank_name";
+  // DROP TYPE "public"."enum_event_affiliate_ranks_rank_name";
+  // DROP TYPE "public"."enum_event_affiliate_ranks_status";
+  // DROP TYPE "public"."enum_affiliate_user_ranks_current_rank";
+  // DROP TYPE "public"."enum_affiliate_user_ranks_pending_rank_upgrade";
+  // DROP TYPE "public"."enum_affiliate_rank_logs_action_type";
+  // DROP TYPE "public"."enum_affiliate_rank_logs_rank_before";
+  // DROP TYPE "public"."enum_affiliate_rank_logs_rank_after";`)
 }

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -62,7 +62,7 @@ import * as migration_20250611_080103_add_affiliate_to_order_collection from './
 import * as migration_20250612_060257_add_promotions_to_affiliate_setting from './20250612_060257_add_promotions_to_affiliate_setting';
 import * as migration_20250612_102521_update_affiliate_link from './20250612_102521_update_affiliate_link';
 import * as migration_20250619_091356 from './20250619_091356';
-import * as migration_20250621_175024_create_affiliate_ranks from './20250621_175024_create_affiliate_ranks';
+// import * as migration_20250621_175024_create_affiliate_ranks from './20250621_175024_create_affiliate_ranks';
 
 export const migrations = [
   {
@@ -386,8 +386,10 @@ export const migrations = [
     name: '20250619_091356',
   },
   {
-    up: migration_20250621_175024_create_affiliate_ranks.up,
-    down: migration_20250621_175024_create_affiliate_ranks.down,
-    name: '20250621_175024_create_affiliate_ranks'
+
+    // temp, will remove after affiliate ranks applied on prod
+    // up: migration_20250621_175024_create_affiliate_ranks.up,
+    // down: migration_20250621_175024_create_affiliate_ranks.down,
+    // name: '20250621_175024_create_affiliate_ranks'
   },
 ];

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -1542,7 +1542,7 @@ export interface AffiliateUserRank {
    */
   totalRevenue: number;
   /**
-   * Tổng doanh thu từ các đơn hàng của Affiliate User
+   * Tổng doanh thu trước giảm giá từ các đơn hàng của Affiliate User
    */
   totalRevenueBeforeDiscount: number;
   /**

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -47,6 +47,7 @@ import { AffiliateRanks } from './collections/Affiliate/AffiliateRanks'
 import { EventAffiliateRanks } from './collections/Affiliate/EventAffiliateRanks'
 import { AffiliateRankLogs } from './collections/Affiliate/AffiliateRankLogs'
 import { AffiliateUserRanks } from './collections/Affiliate/AffiliateUserRank'
+import { HIDE_AFFILIATE_RANK_CONFIG } from './collections/Affiliate/helper'
 // import { sendMailJob } from './collections/Emails/jobs/sendMail'
 
 const filename = fileURLToPath(import.meta.url)
@@ -149,10 +150,9 @@ export default buildConfig({
     FAQs,
     Admins,
     Emails,
-    AffiliateRanks,
-    EventAffiliateRanks,
-    AffiliateUserRanks,
-    AffiliateRankLogs,
+    ...(HIDE_AFFILIATE_RANK_CONFIG
+      ? []
+      : [AffiliateRanks, EventAffiliateRanks, AffiliateUserRanks, AffiliateRankLogs]),
     AffiliateLinks,
     AffiliateSettings,
     AffiliateClickLogs,


### PR DESCRIPTION
## ✨ Summary by Git AI

### 🔥 Changes
- Added a config to hide affiliate ranks feature based on environment.
- This allows disabling the feature on production while still developing it in other environments.
- Added condition to hide affiliate ranks config to prevent create affiliate ranks on production

## Summary by Sourcery

Introduce an environment-based toggle to hide affiliate ranks features in production by disabling migrations, excluding collections, and conditionally rendering related UI and navigation.

New Features:
- Add HIDE_AFFILIATE_RANK_CONFIG flag to control visibility of affiliate ranks features based on NEXT_PUBLIC_ENVIRONMENT.

Enhancements:
- Comment out affiliate ranks migration and SQL execution to prevent applying the migration in production.
- Exclude affiliate rank collections from payload.config when the hide flag is set.
- Conditionally hide the Affiliate Ranks section and dashboard navigation entry in Admin views based on the hide flag.
- Fix the documentation comment for totalRevenueBeforeDiscount in payload-types.ts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The display of "Affiliate Ranks" sections and related collections is now conditionally controlled based on the environment, hiding them in production or when not explicitly enabled.

- **Bug Fixes**
  - Updated navigation logic to correctly insert management affiliate links.

- **Chores**
  - Temporarily disabled the affiliate ranks database migration.
  - Improved comments for property descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->