### PR TITLE
refactor: initialize listPromotionsRef with promotions prop

### DIFF
--- a/src/components/EventDetail/SeatReservation/SeatMapSelection/ConfirmOrderModal.tsx
+++ b/src/components/EventDetail/SeatReservation/SeatMapSelection/ConfirmOrderModal.tsx
@@ -166,7 +166,7 @@ const ConfirmOrderModal = ({
 
   const [promotionCode, setPromotionCode] = useState<string>('')
   
-  const listPromotionsRef = useRef<Promotion[]>([])
+  const listPromotionsRef = useRef<Promotion[]>(promotions)
 
   useEffect(() => {
     listPromotionsRef.current = promotions
@@ -186,9 +186,6 @@ const ConfirmOrderModal = ({
             .then((res) => res.data)
 
           if (!cancelled && isAppliedPromotion(affiliatePromotionInfo, ticketSelected, event)) {
-            if(!listPromotionsRef.current) {
-              listPromotionsRef.current = []
-            }
 
             // check exist fist
             if(!listPromotionsRef.current.find((promo) => promo.code === affiliatePromotionInfo.code)) {


### PR DESCRIPTION
## ✨ Summary by Git AI

### 🔥 Changes
- Initialize `listPromotionsRef` with the `promotions` prop to ensure it's initially populated.
- Remove redundant check for `listPromotionsRef.current` being null or undefined before pushing a new promotion.

## Summary by Sourcery

Initialize the promotions ref with the incoming promotions prop and remove an unnecessary null check.

Enhancements:
- Start listPromotionsRef with the promotions prop instead of an empty array.
- Remove redundant null/undefined check before pushing a new promotion.