### PR TITLE
feat: Update affiliate revenue calculations and descriptions

### DIFF
--- a/src/collections/Affiliate/AffiliateUserRank.ts
+++ b/src/collections/Affiliate/AffiliateUserRank.ts
@@ -60,12 +60,12 @@ export const AffiliateUserRanks: CollectionConfig = {
     {
       name: 'totalRevenue',
       type: 'number',
-      label: 'Tổng Doanh Thu sau khi trừ VAT (VND)',
+      label: 'Tổng Doanh Thu Trước Thuế (VND) (Chưa trừ VAT) (Đã tính giảm giá nếu có)',
       required: true,
       defaultValue: 0,
       admin: {
         description:
-          'Tổng doanh thu từ các đơn hàng của Affiliate User.',
+          'Tổng doanh thu từ các đơn hàng của Affiliate User. Sẽ tính phần thưởng dựa trên giá trị này',
         readOnly: true,
         // disabled: true,
       },
@@ -77,7 +77,20 @@ export const AffiliateUserRanks: CollectionConfig = {
       required: true,
       defaultValue: 0,
       admin: {
-        description: 'Tổng Tiền trước khi trừ thuế VAT của Affiliate User',
+        description: 'Tổng tiền trước khi trừ thuế VAT của Affiliate User',
+        readOnly: true,
+        // disabled: true,
+      },
+    },
+    {
+      name: 'totalRevenueAfterTax',
+      type: 'number',
+      label: 'Tổng Tiền Sau Thuế (VND) (Đã bao gồm VAT) (Đã tính giảm giá nếu có)',
+      required: true,
+      defaultValue: 0,
+      admin: {
+        description:
+          'Tổng tiền từ các đơn hàng của Affiliate User.',
         readOnly: true,
         // disabled: true,
       },
@@ -85,11 +98,11 @@ export const AffiliateUserRanks: CollectionConfig = {
     {
       name: 'totalRevenueBeforeDiscount',
       type: 'number',
-      label: 'Tổng Tiền Trước Giảm Giá (VND) (Chưa trừ VAT)',
+      label: 'Tổng Tiền Trước Giảm Giá (VND) (Đã bao gồm VAT)',
       required: true,
       defaultValue: 0,
       admin: {
-        description: 'Tổng Tiền trước giảm giá từ các đơn hàng của Affiliate User',
+        description: 'Tổng tiền trước giảm giá từ các đơn hàng của Affiliate User',
         readOnly: true,
         // disabled: true,
       },

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -1539,15 +1539,19 @@ export interface AffiliateUserRank {
    */
   totalPoints: number;
   /**
-   * Tổng doanh thu từ các đơn hàng của Affiliate User.
+   * Tổng doanh thu từ các đơn hàng của Affiliate User. Sẽ tính phần thưởng dựa trên giá trị này
    */
   totalRevenue: number;
   /**
-   * Tổng Tiền trước khi trừ thuế VAT của Affiliate User
+   * Tổng tiền trước khi trừ thuế VAT của Affiliate User
    */
   totalRevenueBeforeTax: number;
   /**
-   * Tổng Tiền trước giảm giá từ các đơn hàng của Affiliate User
+   * Tổng tiền từ các đơn hàng của Affiliate User.
+   */
+  totalRevenueAfterTax: number;
+  /**
+   * Tổng tiền trước giảm giá từ các đơn hàng của Affiliate User
    */
   totalRevenueBeforeDiscount: number;
   /**
@@ -1614,11 +1618,15 @@ export interface EventAffiliateUserRank {
    */
   totalRevenue: number;
   /**
-   * Tổng Tiền trước khi trừ thuế VAT của Affiliate User
+   * Tổng tiền trước khi trừ thuế VAT của Affiliate User
    */
   totalRevenueBeforeTax: number;
   /**
-   * Tổng Tiền trước giảm giá từ các đơn hàng của Affiliate User
+   * Tổng tiền từ các đơn hàng của Affiliate User.
+   */
+  totalRevenueAfterTax: number;
+  /**
+   * Tổng tiền trước giảm giá từ các đơn hàng của Affiliate User
    */
   totalRevenueBeforeDiscount: number;
   /**
@@ -3175,6 +3183,7 @@ export interface AffiliateUserRanksSelect<T extends boolean = true> {
   totalPoints?: T;
   totalRevenue?: T;
   totalRevenueBeforeTax?: T;
+  totalRevenueAfterTax?: T;
   totalRevenueBeforeDiscount?: T;
   totalTicketsSold?: T;
   totalCommissionEarned?: T;
@@ -3198,6 +3207,7 @@ export interface EventAffiliateUserRanksSelect<T extends boolean = true> {
   totalPoints?: T;
   totalRevenue?: T;
   totalRevenueBeforeTax?: T;
+  totalRevenueAfterTax?: T;
   totalRevenueBeforeDiscount?: T;
   totalTicketsSold?: T;
   totalCommissionEarned?: T;


### PR DESCRIPTION
## ✨ Summary by Git AI

### 🔥 Changes
- Update affiliate revenue calculation to use total revenue before tax after discount
- Add 'totalRevenueAfterTax' field to track total revenue after tax and discount
- Update descriptions and labels for revenue fields to clarify tax and discount inclusion
- Adjust reward calculation logic to use pre-tax revenue for commission and ticket rewards
- Refactor affiliate rank update logic to account for accumulated points and revenue
              