### PR TITLE
fix: Only count completed orders and active links. Remove commission and small text in performance boxes

### DIFF
--- a/src/app/(affiliate)/api/affiliate/link-breakdown/route.ts
+++ b/src/app/(affiliate)/api/affiliate/link-breakdown/route.ts
@@ -40,6 +40,7 @@ export async function GET(request: NextRequest) {
             WHERE orders.affiliate_affiliate_link_id = affiliate_links.id
               AND orders.created_at >= ${startDate}
               AND orders.created_at <= ${endDate}
+              AND orders.status = 'completed'
           ) AS orders,
 
           -- Calculate gross revenue for this link
@@ -48,19 +49,22 @@ export async function GET(request: NextRequest) {
             WHERE orders.affiliate_affiliate_link_id = affiliate_links.id
               AND orders.created_at >= ${startDate}
               AND orders.created_at <= ${endDate}
+              AND orders.status = 'completed'
           ) AS gross_revenue,
 
           -- Calculate tickets for this link
           (SELECT COUNT(*)
-            FROM tickets t
-            INNER JOIN orders o ON t.order_id = o.id
-            WHERE o.affiliate_affiliate_link_id = affiliate_links.id
-              AND o.created_at >= ${startDate}
-              AND o.created_at <= ${endDate}
+            FROM tickets
+            INNER JOIN orders ON tickets.order_id = orders.id
+            WHERE orders.affiliate_affiliate_link_id = affiliate_links.id
+              AND orders.created_at >= ${startDate}
+              AND orders.created_at <= ${endDate}
+              AND orders.status = 'completed'
           ) AS tickets_issued
 
         FROM affiliate_links
         WHERE affiliate_links.affiliate_user_id = ${userRequest.id}
+          AND affiliate_links.status = 'active'
       ),
 
       calculated_metrics AS (

--- a/src/app/(affiliate)/api/affiliate/performance/route.ts
+++ b/src/app/(affiliate)/api/affiliate/performance/route.ts
@@ -22,8 +22,10 @@ export async function GET(request: NextRequest) {
           FROM orders
           INNER JOIN affiliate_links ON orders.affiliate_affiliate_link_id = affiliate_links.id
           WHERE affiliate_links.affiliate_user_id = ${userRequest.id}
+            AND affiliate_links.status = 'active'
             AND orders.created_at >= ${startDate} 
             AND orders.created_at <= ${endDate}
+            AND orders.status = 'completed'
         ) AS total_revenue,
         COUNT(DISTINCT tickets.id) AS total_tickets,
 
@@ -45,8 +47,10 @@ export async function GET(request: NextRequest) {
         AND affiliate_click_logs.created_at >= ${startDate} AND affiliate_click_logs.created_at <= ${endDate}
       LEFT JOIN orders ON orders.affiliate_affiliate_link_id = affiliate_links.id
         AND orders.created_at >= ${startDate} AND orders.created_at <= ${endDate}
+        AND orders.status = 'completed'
       LEFT JOIN tickets ON tickets.order_id = orders.id
       WHERE affiliate_links.affiliate_user_id = ${userRequest.id}
+        AND affiliate_links.status = 'active'
     `) as { rows: any[] }
 
     return NextResponse.json({

--- a/src/app/(affiliate)/api/affiliate/source-campaign-breakdown/route.ts
+++ b/src/app/(affiliate)/api/affiliate/source-campaign-breakdown/route.ts
@@ -24,6 +24,8 @@ export async function GET(request: NextRequest) {
         INNER JOIN affiliate_links ON orders.affiliate_affiliate_link_id = affiliate_links.id
         WHERE orders.created_at >= ${startDate} AND orders.created_at <= ${endDate}
           AND affiliate_links.affiliate_user_id = ${userRequest.id}
+          AND orders.status = 'completed'
+          AND affiliate_links.status = 'active'
         GROUP BY source, campaign
       ),
       total_revenue AS (

--- a/src/components/Affiliate/PerformanceAnalytics.tsx
+++ b/src/components/Affiliate/PerformanceAnalytics.tsx
@@ -211,7 +211,7 @@ export function PerformanceAnalytics() {
       </Card> */}
 
       {/* Summary Cards */}
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-5">
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
         <Card className="shadow-md">
           <CardHeader className="pb-2">
             <CardTitle className="text-sm font-medium">Total Clicks</CardTitle>
@@ -232,9 +232,9 @@ export function PerformanceAnalytics() {
                   <div className="text-2xl font-bold">
                     {performanceData?.clicks.toLocaleString()}
                   </div>
-                  <p className="text-xs text-muted-foreground">
+                  {/* <p className="text-xs text-muted-foreground">
                     {`Across all links`}
-                  </p>
+                  </p> */}
                 </>
               )
             }
@@ -260,9 +260,9 @@ export function PerformanceAnalytics() {
                   <div className="text-2xl font-bold">
                     {performanceData?.orders.toLocaleString()}
                   </div>
-                  <p className="text-xs text-muted-foreground">
+                  {/* <p className="text-xs text-muted-foreground">
                     {`Conversion Rate: ${performanceData?.overallConversionRate.toLocaleString()}%`}
-                  </p>
+                  </p> */}
                 </>
               )
             }
@@ -288,9 +288,9 @@ export function PerformanceAnalytics() {
                   <div className="text-2xl font-bold">
                     {performanceData?.ticketsIssued.toLocaleString()}
                   </div>
-                  <p className="text-xs text-muted-foreground">
+                  {/* <p className="text-xs text-muted-foreground">
                     {`Avg: ${performanceData?.averageTicketsPerOrder.toLocaleString()} per order`}
-                  </p> 
+                  </p>  */}
                 </>
               )
             }
@@ -316,15 +316,15 @@ export function PerformanceAnalytics() {
                   <div className="text-2xl font-bold">
                     {`${formatMoney(performanceData?.grossRevenue ?? 0)}`}
                   </div>
-                  <p className="text-xs text-muted-foreground">
+                  {/* <p className="text-xs text-muted-foreground">
                     {`Before discounts`}
-                  </p>
+                  </p> */}
                 </>
               )
             }
           </CardContent>
         </Card>
-        <Card className="bg-gray-200 text-gray-800 shadow-md">
+        {/* <Card className="bg-gray-200 text-gray-800 shadow-md">
           <CardHeader className="pb-2">
             <CardTitle className="text-sm font-medium">Your Commission</CardTitle>
           </CardHeader>
@@ -351,7 +351,7 @@ export function PerformanceAnalytics() {
               )
             }
           </CardContent>
-        </Card>
+        </Card> */}
       </div>
 
       {/* Link Performance Table */}
@@ -389,7 +389,7 @@ export function PerformanceAnalytics() {
                   <TableHead className="text-center">Conversion</TableHead>
                   <TableHead className="text-center">Gross Revenue</TableHead>
                   <TableHead className="text-center">Net Revenue</TableHead>
-                  <TableHead className="text-center bg-gray-200 text-gray-800">Commission</TableHead>
+                  {/* <TableHead className="text-center bg-gray-200 text-gray-800">Commission</TableHead> */}
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -419,9 +419,9 @@ export function PerformanceAnalytics() {
                     <TableCell className="text-center py-8">
                       <Skeleton className="h-4  rounded-xl bg-black/10" />
                     </TableCell>
-                    <TableCell className="text-center py-8">
+                    {/* <TableCell className="text-center py-8">
                       <Skeleton className="h-4  rounded-xl bg-black/10" />
-                    </TableCell>
+                    </TableCell> */}
                   </TableRow>
                 ) : linkBreakdownData?.length === 0 || !linkBreakdownData ? (
                     <TableRow>
@@ -436,9 +436,9 @@ export function PerformanceAnalytics() {
                       <TableCell className="text-center">
                         <div className="space-y-1">
                           <Badge variant="outline" className="text-xs">
-                            {link.utmSource}
+                            {link.utmSource ? link.utmSource : 'Unknown'}
                           </Badge>
-                          <div className="text-xs text-muted-foreground">{link.utmCampaign}</div>
+                          <div className="text-xs text-muted-foreground">{link.utmCampaign ? link.utmCampaign : 'Unknown'}</div>
                         </div>
                       </TableCell>
                       <TableCell className="text-center">{link.clicks.toLocaleString()}</TableCell>
@@ -456,9 +456,9 @@ export function PerformanceAnalytics() {
                       </TableCell>
                       <TableCell className="text-center">{formatMoney(link.grossRevenue)}</TableCell>
                       <TableCell className="text-center">{formatMoney(link.netRevenue)}</TableCell>
-                      <TableCell className="text-center bg-gray-200 text-gray-800 font-medium text-green-600">
+                      {/* <TableCell className="text-center bg-gray-200 text-gray-800 font-medium text-green-600">
                         {formatMoney(link.commission)}
-                      </TableCell>
+                      </TableCell> */}
                     </TableRow>
                   ))
                 )}
@@ -523,7 +523,7 @@ export function PerformanceAnalytics() {
               sourceCampaignBreakdownData?.bySource.map((item) => (
               <div key={item.source} className="space-y-2">
                 <div className="flex items-center justify-between">
-                  <span className="text-sm font-medium capitalize">{item.source}</span>
+                  <span className="text-sm font-medium capitalize">{item.source ? item.source : 'Unknown'}</span>
                   <span className="text-sm text-muted-foreground">
                     {formatMoney(item.revenue)} ({item.percentage.toLocaleString()}%)
                   </span>
@@ -554,7 +554,7 @@ export function PerformanceAnalytics() {
               sourceCampaignBreakdownData?.byCampaign.map((item) => (
                 <div key={item.campaign} className="space-y-2">
                   <div className="flex items-center justify-between">
-                    <span className="text-sm font-medium">{item.campaign}</span>
+                    <span className="text-sm font-medium">{item.campaign ? item.campaign: 'Unknown'}</span>
                     <span className="text-sm text-muted-foreground">
                       {formatMoney(item.revenue)} ({item.percentage.toLocaleString()}%)
                     </span>


### PR DESCRIPTION
- Only count completed orders and active links in affiliate dashboard
- Remove commission and small text in performance boxes
- If utmSource or Campaign is unknown, The UI render as 'Unknown'