### PR TITLE
feat: always show affiliate ranks

### DIFF
--- a/src/collections/Affiliate/helper/index.ts
+++ b/src/collections/Affiliate/helper/index.ts
@@ -1,6 +1,0 @@
-// temp, should be deleted in the future after full affiliate ranks applied on production
-const env = process.env.NEXT_PUBLIC_ENVIRONMENT
-
-export const HIDE_AFFILIATE_RANK_CONFIG = !env || env === 'production'
-
-console.log('HIDE_AFFILIATE_RANK_CONFIG', HIDE_AFFILIATE_RANK_CONFIG)

--- a/src/components/AdminViews/ManagementAffiliate/Page.client.tsx
+++ b/src/components/AdminViews/ManagementAffiliate/Page.client.tsx
@@ -19,7 +19,6 @@ import DashboardTab from './components/DashboardTab'
 import ManageAffiliateUserTab from './components/ManageAffiliateUserTab'
 import AffiliateClickLogsTab from './components/AffiliateClickLogsTab'
 import { AffiliateCollectionList } from './AffiliateCollectionList'
-import { HIDE_AFFILIATE_RANK_CONFIG } from '@/collections/Affiliate/helper'
 
 interface Props {
   affiliateUsers: User[]
@@ -55,12 +54,10 @@ const AffiliateManagementClient: React.FC<Props> = ({
             Manage affiliate users, track performance, and configure affiliate settings
           </p>
         </div>
-        {!HIDE_AFFILIATE_RANK_CONFIG && (
-          <div style={{ marginBottom: 'calc(var(--base))' }}>
-            <h2 style={{ marginBottom: 'calc(var(--base))' }}>Affiliate Ranks</h2>
-            <AffiliateCollectionList />
-          </div>
-        )}
+        <div style={{ marginBottom: 'calc(var(--base))' }}>
+          <h2 style={{ marginBottom: 'calc(var(--base))' }}>Affiliate Ranks</h2>
+          <AffiliateCollectionList />
+        </div>
 
         <PayloadTabs defaultValue="dashboard">
           <PayloadTabsList>

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -48,7 +48,6 @@ import { EventAffiliateRanks } from './collections/Affiliate/EventAffiliateRanks
 import { AffiliateRankLogs } from './collections/Affiliate/AffiliateRankLogs'
 import { AffiliateUserRanks } from './collections/Affiliate/AffiliateUserRank'
 import { EventAffiliateUserRanks } from './collections/Affiliate/EventAffiliateUserRanks'
-import { HIDE_AFFILIATE_RANK_CONFIG } from './collections/Affiliate/helper'
 import { MembershipCollections } from './collections/Membership'
 // import { sendMailJob } from './collections/Emails/jobs/sendMail'
 
@@ -135,7 +134,7 @@ export default buildConfig({
     Media,
     Categories,
     Users,
-    ...(HIDE_AFFILIATE_RANK_CONFIG ? [] : MembershipCollections),
+    ...MembershipCollections,
     CheckInRecords,
     SeatingCharts,
     Events,
@@ -153,15 +152,11 @@ export default buildConfig({
     FAQs,
     Admins,
     Emails,
-    ...(HIDE_AFFILIATE_RANK_CONFIG
-      ? []
-      : [
-          AffiliateRanks,
-          EventAffiliateRanks,
-          AffiliateUserRanks,
-          EventAffiliateUserRanks,
-          AffiliateRankLogs,
-        ]),
+    AffiliateRanks,
+    EventAffiliateRanks,
+    AffiliateUserRanks,
+    EventAffiliateUserRanks,
+    AffiliateRankLogs,
     AffiliateLinks,
     AffiliateSettings,
     AffiliateClickLogs,


### PR DESCRIPTION
## ✨ Summary by Git AI

### 🔥 Changes
- Removes the environment-based configuration that was previously used to conditionally hide affiliate rank features.
- Makes affiliate ranks visible in all environments.

## Summary by Sourcery

Enable affiliate rank features across all environments by eliminating the environment-based hide configuration.

New Features:
- Always include affiliate rank collections in the payload configuration
- Display the Affiliate Ranks section in the admin UI unconditionally

Enhancements:
- Remove the HIDE_AFFILIATE_RANK_CONFIG flag and its conditional logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The "Affiliate Ranks" section and related features are now always visible and accessible to all users.

* **Chores**
  * Removed environment-based logic that previously controlled the visibility of affiliate ranks and related collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->