### PR TITLE
feat: hide affiliate registration in production

### DIFF
--- a/src/app/(affiliate)/affiliate/register/page.tsx
+++ b/src/app/(affiliate)/affiliate/register/page.tsx
@@ -47,8 +47,10 @@ type RegisterFormData = z.infer<typeof registerSchema>
 export default function AffiliateRegisterPage() {
   const { toast } = useToast()
   const router = useRouter()
+
+  // hidden registration form when env is production
   const env = process.env.NEXT_PUBLIC_ENVIRONMENT
-  const showRegistrationPage = !env || env === 'production'
+  const hiddenRegistrationPage = !env || env === 'production'
  
   const form = useForm<RegisterFormData & { acceptTerms: boolean }>({
     resolver: zodResolver(registerSchema),
@@ -113,7 +115,7 @@ export default function AffiliateRegisterPage() {
     router.back()
   }
 
-  if (!showRegistrationPage) {
+  if (hiddenRegistrationPage) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-white py-10 sm:py-16 lg:py-20">
         <div className="max-w-lg w-full space-y-8 px-4">

--- a/src/app/(affiliate)/api/affiliate/register/route.ts
+++ b/src/app/(affiliate)/api/affiliate/register/route.ts
@@ -37,9 +37,9 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         {
           success: false,
-          error: 'Affiliate registration is currently unavailable.'
+          error: 'Page not found',
         },
-        { status: 503 },
+        { status: 404 },
       )
     }
 
@@ -63,7 +63,10 @@ export async function POST(request: NextRequest) {
     const existing = await payload.find({
       collection: 'users',
       where: {
-        or: [{ email: { equals: String(value.email).toLowerCase() } }, { phoneNumber: { equals: value.phoneNumber } }],
+        or: [
+          { email: { equals: String(value.email).toLowerCase() } },
+          { phoneNumber: { equals: value.phoneNumber } },
+        ],
       },
       limit: 1,
     })

--- a/src/app/(affiliate)/api/affiliate/register/route.ts
+++ b/src/app/(affiliate)/api/affiliate/register/route.ts
@@ -30,9 +30,10 @@ const affiliateRegisterSchema = Joi.object({
 
 export async function POST(request: NextRequest) {
   try {
+    // hidden registration form when env is production
     const env = process.env.NEXT_PUBLIC_ENVIRONMENT
-    const showRegistrationPage = !env || env === 'production'
-    if (!showRegistrationPage) {
+    const hiddenRegistrationPage = !env || env === 'production'
+    if (hiddenRegistrationPage) {
       return NextResponse.json(
         {
           success: false,

--- a/src/app/(user)/api/user/affiliate-register/route.ts
+++ b/src/app/(user)/api/user/affiliate-register/route.ts
@@ -6,9 +6,21 @@ import { signJwtToken } from '@/app/(user)/utils/auth/signJwtToken'
 
 export async function POST(_req: NextRequest) {
   try {
+    // remove when production is ready
+    const env = process.env.NEXT_PUBLIC_ENVIRONMENT
+    const hiddenRegistrationPage = !env || env === 'production'
+    if (hiddenRegistrationPage) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'Page not found',
+        },
+        { status: 404 },
+      )
+    }
     // Verify the JWT token
     const userRequest = await authorizeApiRequest()
-    
+
     const payload = await getPayload()
 
     // Fetch the user
@@ -20,7 +32,7 @@ export async function POST(_req: NextRequest) {
         id: true,
         role: true,
         affiliateStatus: true,
-      }
+      },
     })
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 })
@@ -48,13 +60,13 @@ export async function POST(_req: NextRequest) {
       },
     })
 
-    // Sign JWT token if approved 
+    // Sign JWT token if approved
     await signJwtToken({
       fieldsToSign: {
         id: user.id,
         email: user.email,
-        role: USER_ROLE.affiliate.value
-      }
+        role: USER_ROLE.affiliate.value,
+      },
     })
 
     return NextResponse.json({


### PR DESCRIPTION
## ✨ Summary by Git AI

### 🔥 Changes
- Hides the affiliate registration form when the environment is set to production.
- Prevents unauthorized affiliate registrations in the production environment.

## Summary by Sourcery

Hide the affiliate registration form and disable its API endpoint in production environments to prevent unauthorized registrations.

New Features:
- Hide affiliate registration page when running in production environment
- Block the affiliate registration API endpoint in production

Enhancements:
- Rename variable and invert logic for registration visibility based on environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated environment-based logic to hide the affiliate registration form and endpoint in production or when the environment is undefined.
  * The "Coming Soon" placeholder page is now shown instead of the registration form under these conditions.
  * Added clarifying comments regarding registration form visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Updated the affiliate registration API route to return a 404 error in production.
- Added environment check to hide the affiliate registration page when the environment is production.