### PR TITLE
fix: ensure logError calls are awaited in ZaloPay callback

### DIFF
--- a/src/app/(payload)/api/zalopay/callback/route.ts
+++ b/src/app/(payload)/api/zalopay/callback/route.ts
@@ -60,7 +60,7 @@ export async function POST(request: NextRequest) {
     } catch (error: any) {
       await payload.db.rollbackTransaction(transactionID)
 
-      logError({
+      await logError({
         payload,
         action: 'PAYMENT_CALLBACK_ERROR',
         description: `Error processing payment callback: ${error instanceof Error ? error.message : 'An unknown error occurred'}`,
@@ -81,7 +81,7 @@ export async function POST(request: NextRequest) {
     }
   } catch (error: any) {
     console.error('Error processing payment:', error)
-    logError({
+    await logError({
       payload,
       action: 'PAYMENT_CALLBACK_ERROR',
       description: `Error processing payment callback: ${error instanceof Error ? error.message : 'An unknown error occurred'}`,


### PR DESCRIPTION
## ✨ Summary by Git AI

### 🔥 Changes
- Await the `logError` function calls in the ZaloPay callback route to ensure errors are properly logged before the function exits.
- This fixes a potential issue where errors might not be logged if the function exits before the logging operation completes.
              