### PR TITLE
chore: remove unused cron job

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,10 +1,6 @@
 {
   "crons": [
     {
-      "path": "/api/cron/send-qr-event-ticket",
-      "schedule": "*/2 * * * *"
-    },
-    {
       "path": "/api/cron/send-email",
       "schedule": "*/2 * * * *"
     },


### PR DESCRIPTION
## ✨ Summary by Git AI

### 🔥 Changes
- Removed the `/api/cron/send-qr-event-ticket` cron job from `vercel.json`.
- This cron job was no longer needed.
              