### PR TITLE
feat: add cron job for sending qr event tickets

### DIFF
--- a/src/app/api/cron/send-qr-event-ticket/route.ts
+++ b/src/app/api/cron/send-qr-event-ticket/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getPayload } from '@/payload-config/getPayloadConfig'
 import { addQueueEmail } from '@/collections/Emails/utils'
-import { EMAIL_CC, EMAIL_QR_EVENT_GUIDELINE_URL, EMAIL_QR_EVENT_MAP_STAGE } from '@/config/email'
+import { EMAIL_QR_EVENT_GUIDELINE_URL, EMAIL_QR_EVENT_MAP_STAGE } from '@/config/email'
 import { toZonedTime, format as tzFormat } from 'date-fns-tz'
 import { generateEventTicketEmailHtml } from '@/mail/templates/EventTicketEmail'
 import { getServerSideURL } from '@/utilities/getURL'
@@ -150,7 +150,7 @@ export async function GET(req: NextRequest) {
             payload,
             resendMailData: {
               to: order.userEmail,
-              cc: EMAIL_CC,
+              // cc: EMAIL_CC,
               subject: `✨ Step Into the Story – Your ${event.title} Tickets Are Here`,
               html,
             },

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,10 @@
 {
   "crons": [
     {
+      "path": "/api/cron/send-qr-event-ticket",
+      "schedule": "*/2 * * * *"
+    },
+    {
       "path": "/api/cron/send-email",
       "schedule": "*/2 * * * *"
     },


### PR DESCRIPTION
## ✨ Summary by Git AI

### 🔥 Changes
- Adds a cron job to periodically send QR event tickets.
- The cron job is scheduled to run every 2 minutes.
- Removed the EMAIL_CC configuration from being used when sending event ticket emails.
- This change prevents carbon copying (CC) recipients in event ticket emails.          

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new scheduled task to automatically trigger QR event ticket sending every 2 minutes.
  * Disabled carbon copy recipients for the event ticket email notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
