### PR TITLE
feat(auth): configure admin token expiration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,9 @@ DATABASE_URI=postgres://postgres:<password>@127.0.0.1:5432/your-database-name
 # Used to encrypt JWT tokens
 PAYLOAD_SECRET=YOUR_SECRET_HERE
 
+# Admin Authentication
+ADMIN_TOKEN_EXPIRATION_IN_SECONDS=7200
+
 # Used to configure CORS, format links and more. No trailing slash
 NEXT_PUBLIC_SERVER_URL=http://localhost:3000
 

--- a/src/collections/Admins.ts
+++ b/src/collections/Admins.ts
@@ -1,5 +1,8 @@
 import type { CollectionConfig } from 'payload'
 import { isAdminOrSuperAdmin, isSuperAdmin } from '@/access/isAdminOrSuperAdmin'
+import { ADMIN_TOKEN_EXPIRATION_IN_SECONDS } from '@/config/app'
+
+console.log('ADMIN_TOKEN_EXPIRATION_IN_SECONDS', ADMIN_TOKEN_EXPIRATION_IN_SECONDS)
 
 const Admins: CollectionConfig = {
   slug: 'admins',
@@ -7,7 +10,9 @@ const Admins: CollectionConfig = {
     useAsTitle: 'email',
     group: 'System',
   },
-  auth: true, // Enable authentication for this collection
+  auth: {
+    tokenExpiration: ADMIN_TOKEN_EXPIRATION_IN_SECONDS,
+  }, // Enable authentication for this collection
   access: {
     read: ({ req: { user } }) => {
       if (!user) return false

--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -9,3 +9,7 @@ export const NODE_ENV = process.env.NODE_ENV
 export const IS_LOCAL_DEVELOPMENT = !NODE_ENV || ['development', 'local'].includes(NODE_ENV)
 
 export const X_API_KEY = process.env.X_API_KEY || 'X_API_KEY'
+
+export const ADMIN_TOKEN_EXPIRATION_IN_SECONDS = process.env.ADMIN_TOKEN_EXPIRATION_IN_SECONDS
+  ? parseInt(process.env.ADMIN_TOKEN_EXPIRATION_IN_SECONDS)
+  : 2592000 // 30 days


### PR DESCRIPTION
## ✨ Summary by Git AI

### 🔥 Changes
- Configures the admin token expiration time using an environment variable.
- Sets a default expiration of 30 days if the environment variable is not defined.
- Updates the Admins collection to use the configured token expiration time.
              