### PR TITLE
feat: Implement backend logic for affiliate rank upgrade

### DIFF
--- a/src/app/(affiliate)/api/affiliate/confirm-event-rank-upgrade/route.ts
+++ b/src/app/(affiliate)/api/affiliate/confirm-event-rank-upgrade/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from 'next/server'
+import payload from 'payload'
+import { authorizeApiRequest } from '@/app/(affiliate)/utils/authorizeApiRequest'
+
+export async function POST(req: NextRequest) {
+  try {
+    const user = await authorizeApiRequest()
+    const body = await req.json()
+    const { eventIds, newRank } = body
+
+    if (!Array.isArray(eventIds) || !newRank) {
+      return NextResponse.json({ error: 'Missing eventIds or newRank' }, { status: 400 })
+    }
+
+    // Disable record cũ và tạo record mới cho từng event
+    for (const eventId of eventIds) {
+      await payload.update({
+        collection: 'event-affiliate-user-ranks',
+        where: {
+          affiliateUser: { equals: user.id },
+          event: { equals: eventId },
+        },
+        data: {
+          status: 'disabled',
+        },
+      })
+      await payload.create({
+        collection: 'event-affiliate-user-ranks',
+        data: {
+          affiliateUser: user.id,
+          event: eventId,
+          eventAffiliateRank: newRank,
+          status: 'active',
+          totalPoints: 0,
+          totalRevenue: 0,
+          totalRevenueBeforeTax: 0,
+          totalRevenueAfterTax: 0,
+          totalRevenueBeforeDiscount: 0,
+          totalTicketsSold: 0,
+          totalCommissionEarned: 0,
+          totalTicketsRewarded: 0,
+          lastActivityDate: new Date().toISOString(),
+        },
+      })
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    console.error('Error confirming event rank upgrade:', err)
+    return NextResponse.json({ error: 'Server error' }, { status: 500 })
+  }
+}

--- a/src/app/(affiliate)/api/affiliate/notify-event-rank-upgrade/route.ts
+++ b/src/app/(affiliate)/api/affiliate/notify-event-rank-upgrade/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { authorizeApiRequest } from '@/app/(affiliate)/utils/authorizeApiRequest'
+
+// In-memory store
+const notificationsByUser: Record<string, any[]> = {}
+
+export async function POST(req: NextRequest) {
+  try {
+    const user = await authorizeApiRequest() // 🔐 authenticate affiliate user
+    const userId = user.id
+
+    const body = await req.json()
+    const { eligibleEvents, eligibleRank } = body
+
+    if (!Array.isArray(eligibleEvents) || !eligibleRank) {
+      return NextResponse.json({ error: 'Missing eligibleEvents or eligibleRank' }, { status: 400 })
+    }
+
+    // Lưu thông báo
+    notificationsByUser[userId] = [
+      ...(notificationsByUser[userId] || []),
+      {
+        type: 'event-rank-upgrade',
+        rank: eligibleRank,
+        eligibleEvents,
+        timestamp: Date.now(),
+      },
+    ]
+
+    return NextResponse.json({ message: 'Notification saved' })
+  } catch (err) {
+    console.error('Error saving notification:', err)
+    return NextResponse.json({ error: 'Server error' }, { status: 500 })
+  }
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    // Authenticate user
+    const user = await authorizeApiRequest() // 🔐 authenticate affiliate user
+    const notifications = notificationsByUser[user.id] || []
+
+    return NextResponse.json({ notifications })
+  } catch (err) {
+    console.error('Error fetching notifications:', err)
+    return NextResponse.json({ error: 'Server error' }, { status: 500 })
+  }
+}

--- a/src/collections/Affiliate/AffiliateUserRank.ts
+++ b/src/collections/Affiliate/AffiliateUserRank.ts
@@ -89,8 +89,7 @@ export const AffiliateUserRanks: CollectionConfig = {
       required: true,
       defaultValue: 0,
       admin: {
-        description:
-          'Tổng tiền từ các đơn hàng của Affiliate User.',
+        description: 'Tổng tiền từ các đơn hàng của Affiliate User.',
         readOnly: true,
         // disabled: true,
       },
@@ -176,4 +175,60 @@ export const AffiliateUserRanks: CollectionConfig = {
       },
     },
   ],
+  hooks: {
+    afterChange: [
+      async ({ doc, req, operation }) => {
+        if (operation != 'update') return
+        // Fetch all affiliate ranks and sort by minimum points in ascending order
+        const affiliateRanks = await req.payload
+          .find({
+            collection: 'affiliate-ranks',
+            limit: AFFILIATE_RANKS.length,
+            depth: 0,
+            where: {
+              rankName: { in: AFFILIATE_RANKS.map((rank) => rank.value) },
+            },
+          })
+          .then((res) => res.docs.sort((a, b) => b.minPoints - a.minPoints))
+        // Determine the highest eligible rank based on total points
+        const currentPoints = doc.totalPoints || 0
+        const highestEligibleRank = affiliateRanks.find((rank) => currentPoints >= rank.minPoints)
+        // If highest eligible rank != current rank
+        if (highestEligibleRank && highestEligibleRank.rankName !== doc.currentRank) {
+          // update the affiliate user rank
+          await req.payload.update({
+            collection: 'affiliate-user-ranks',
+            id: doc.id,
+            data: {
+              currentRank: highestEligibleRank.rankName,
+            },
+          })
+          // Find elegible event aff user ranks to be updated
+          const eligibleEvents = await req.payload
+            .find({
+              collection: 'event-affiliate-user-ranks',
+              where: {
+                affiliateUser: { equals: doc.affiliateUser },
+                currentRank: { not_equals: highestEligibleRank.rankName },
+              },
+            })
+            .then((res) => res.docs)
+          // Send eligible events to notify-event-rank-upgrade endpoint to notify user
+          if (eligibleEvents.length > 0) {
+            await fetch(`${process.env.NEXT_PUBLIC_SERVER_URL}/api/notify-event-rank-upgrade`, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                eligibleRank: highestEligibleRank.rankName,
+                eligibleEvents: eligibleEvents.map((e) => ({
+                  eventId: e.id,
+                  oldRank: e.eventAffiliateRank,
+                })),
+              }),
+            })
+          }
+        }
+      },
+    ],
+  },
 }

--- a/src/collections/Affiliate/EventAffiliateUserRanks.ts
+++ b/src/collections/Affiliate/EventAffiliateUserRanks.ts
@@ -209,16 +209,16 @@ export const EventAffiliateUserRanks: CollectionConfig = {
         // disabled: true,
       },
     },
-    {
-      name: 'isCompleted',
-      type: 'checkbox',
-      label: 'Đã Hoàn Thành',
-      defaultValue: false,
-      admin: {
-        description:
-          'Khi đã hoàn thành, những giá trị sẽ được tính toán và lưu vào các thông số hạng tổng của Affiliate User. Chỉ thực hiện hành động này sau khi event đã kết thúc',
-      },
-    },
+    // {
+    //   name: 'isCompleted',
+    //   type: 'checkbox',
+    //   label: 'Đã Hoàn Thành',
+    //   defaultValue: false,
+    //   admin: {
+    //     description:
+    //       'Khi đã hoàn thành, những giá trị sẽ được tính toán và lưu vào các thông số hạng tổng của Affiliate User. Chỉ thực hiện hành động này sau khi event đã kết thúc',
+    //   },
+    // },
   ],
   hooks: {
     beforeValidate: [
@@ -234,37 +234,37 @@ export const EventAffiliateUserRanks: CollectionConfig = {
         }
 
         // can not update is completed from true to false
-        if (originalDoc?.isCompleted && !data?.isCompleted) {
-          throw new APIError('Không thể cập nhật trạng thái đã hoàn thành', 400, {}, true)
-        }
+        // if (originalDoc?.isCompleted && !data?.isCompleted) {
+        //   throw new APIError('Không thể cập nhật trạng thái đã hoàn thành', 400, {}, true)
+        // }
 
-        const isChecked = data?.isCompleted && !originalDoc?.isCompleted
+        // const isChecked = data?.isCompleted && !originalDoc?.isCompleted
 
-        // validate isCompleted, just updated to true if the event has been completed
-        if (isChecked) {
-          // check if the event has been completed
-          const event = await req.payload
-            .find({
-              collection: 'events',
-              where: { id: { equals: data.event } },
-              depth: 0,
-              limit: 1,
-            })
-            .then((res) => res.docs?.[0])
+        // // validate isCompleted, just updated to true if the event has been completed
+        // if (isChecked) {
+        //   // check if the event has been completed
+        //   const event = await req.payload
+        //     .find({
+        //       collection: 'events',
+        //       where: { id: { equals: data.event } },
+        //       depth: 0,
+        //       limit: 1,
+        //     })
+        //     .then((res) => res.docs?.[0])
 
-          if (!event) {
-            throw new APIError('Event not found', 400, {}, true)
-          }
+        //   if (!event) {
+        //     throw new APIError('Event not found', 400, {}, true)
+        //   }
 
-          if (
-            event.status === 'completed' ||
-            (event.endDatetime && dateFns.isAfter(new Date(), event.endDatetime))
-          ) {
-            data.isCompleted = true
-          } else {
-            throw new APIError('Event is not completed', 400, {}, true)
-          }
-        }
+        //   if (
+        //     event.status === 'completed' ||
+        //     (event.endDatetime && dateFns.isAfter(new Date(), event.endDatetime))
+        //   ) {
+        //     data.isCompleted = true
+        //   } else {
+        //     throw new APIError('Event is not completed', 400, {}, true)
+        //   }
+        // }
 
         return data
       },
@@ -273,109 +273,108 @@ export const EventAffiliateUserRanks: CollectionConfig = {
       async ({ req, operation, doc, previousDoc }) => {
         if (operation !== 'update') return
 
-        const isChecked = doc?.isCompleted && !previousDoc?.isCompleted
+        // const isChecked = doc?.isCompleted && !previousDoc?.isCompleted
 
         // update totalPoints, totalRevenue, totalRevenueBeforeDiscount, totalTicketsSold, totalCommissionEarned, totalTicketsRewarded to affiliate-user-ranks colleciton
-        if (isChecked) {
-          const affiliateUserId = doc.affiliateUser?.id || doc.affiliateUser
+        // if (isChecked) {
+        const affiliateUserId = doc.affiliateUser?.id || doc.affiliateUser
 
-          // save to affiliate-user-ranks, if it is not exist, create a new one
-          const affiliateUserRank = await req.payload
-            .find({
-              collection: 'affiliate-user-ranks',
-              where: { affiliateUser: { equals: affiliateUserId } },
-              limit: 1,
-              depth: 0,
-            })
-            .then((res) => res.docs?.[0])
+        // save to affiliate-user-ranks, if it is not exist, create a new one
+        const affiliateUserRank = await req.payload
+          .find({
+            collection: 'affiliate-user-ranks',
+            where: { affiliateUser: { equals: affiliateUserId } },
+            limit: 1,
+            depth: 0,
+          })
+          .then((res) => res.docs?.[0])
 
-          const affiliateRanks = await req.payload
-            .find({
-              collection: 'affiliate-ranks',
-              limit: AFFILIATE_RANKS.length,
-              depth: 0,
-              where: {
-                rankName: { in: AFFILIATE_RANKS.map((rank) => rank.value) },
-              },
-            })
-            .then((res) => res.docs)
+        const affiliateRanks = await req.payload
+          .find({
+            collection: 'affiliate-ranks',
+            limit: AFFILIATE_RANKS.length,
+            depth: 0,
+            where: {
+              rankName: { in: AFFILIATE_RANKS.map((rank) => rank.value) },
+            },
+          })
+          .then((res) => res.docs)
 
-          const sortedRanks = affiliateRanks.sort((a, b) => b.minPoints - a.minPoints)
+        const sortedRanks = affiliateRanks.sort((a, b) => b.minPoints - a.minPoints)
 
-          if (!affiliateUserRank) {
-            // create a new one
-            
-            const newRank = sortedRanks.find((rank) => doc.totalPoints >= rank.minPoints)
-            await req.payload.create({
-              collection: 'affiliate-user-ranks',
-              data: {
-                affiliateUser: affiliateUserId,
-                currentRank: newRank?.rankName as AffiliateRank,
-                totalPoints: doc.totalPoints,
-                totalRevenue: doc.totalRevenue,
-                totalRevenueBeforeTax: doc.totalRevenueBeforeTax,
-                totalRevenueAfterTax: doc.totalRevenueAfterTax,
-                totalRevenueBeforeDiscount: doc.totalRevenueBeforeDiscount,
-                totalTicketsSold: doc.totalTicketsSold,
-                totalCommissionEarned: doc.totalCommissionEarned,
-                totalTicketsRewarded: doc.totalTicketsRewarded,
-                lastActivityDate: new Date().toISOString(),
-                rankAchievedDate: new Date().toISOString(),
-              },
-            })
-          } else {
-            // update affiliate user rank
-            let pendingRankUpgrade: AffiliateRank | null = null
-            const totalPoints = (affiliateUserRank.totalPoints || 0) + (doc.totalPoints || 0)
-            const nextRankCanReach = sortedRanks.find((rank) => totalPoints >= rank.minPoints)
-            if (nextRankCanReach && nextRankCanReach.rankName !== affiliateUserRank.currentRank) {
-              pendingRankUpgrade = nextRankCanReach.rankName as AffiliateRank
-            }
-            await req.payload.update({
-              collection: 'affiliate-user-ranks',
-              id: affiliateUserRank.id,
-              data: {
-                pendingRankUpgrade,
-                lastActivityDate: new Date().toISOString(),
-                totalPoints: totalPoints,
-                totalRevenue: (affiliateUserRank.totalRevenue || 0) + (doc.totalRevenue || 0),
-                totalRevenueBeforeTax:
-                  (affiliateUserRank.totalRevenueBeforeTax || 0) + (doc.totalRevenueBeforeTax || 0),
-                totalRevenueAfterTax:
-                  (affiliateUserRank.totalRevenueAfterTax || 0) + (doc.totalRevenueAfterTax || 0),
-                totalRevenueBeforeDiscount:
-                  (affiliateUserRank.totalRevenueBeforeDiscount || 0) +
-                  (doc.totalRevenueBeforeDiscount || 0),
-                totalTicketsSold:
-                  (affiliateUserRank.totalTicketsSold || 0) + (doc.totalTicketsSold || 0),
-                totalCommissionEarned:
-                  (affiliateUserRank.totalCommissionEarned || 0) + (doc.totalCommissionEarned || 0),
-                totalTicketsRewarded:
-                  (affiliateUserRank.totalTicketsRewarded || 0) + (doc.totalTicketsRewarded || 0),
-              },
-            })
-          }
-
-          const pointsBefore = affiliateUserRank?.totalPoints || 0
-          const pointsAfter = pointsBefore + (doc.totalPoints || 0)
-          const pointsChange = pointsAfter - pointsBefore
-          // need to write log
+        if (!affiliateUserRank) {
+          // create a new one
+          const newRank = sortedRanks.find((rank) => doc.totalPoints >= rank.minPoints)
           await req.payload.create({
-            collection: 'affiliate-rank-logs',
+            collection: 'affiliate-user-ranks',
             data: {
               affiliateUser: affiliateUserId,
-              eventAffiliateRank: doc.eventAffiliateRank,
-              rankContext: 'user',
-              pointsChange,
-              pointsBefore,
-              pointsAfter,
-              rankBefore: affiliateUserRank?.currentRank,
-              actionType: AFFILIATE_ACTION_TYPE_LOG.event_completed.value,
-              occurredAt: new Date().toISOString(),
-              description: `Cập nhật điểm tích lũy, doanh thu, số vé bán được, hoa hồng nhận được, số vé thưởng có thể nhận được từ sự kiện sau khi event đã hoàn thành`,
+              currentRank: newRank?.rankName as AffiliateRank,
+              totalPoints: doc.totalPoints,
+              totalRevenue: doc.totalRevenue,
+              totalRevenueBeforeTax: doc.totalRevenueBeforeTax,
+              totalRevenueAfterTax: doc.totalRevenueAfterTax,
+              totalRevenueBeforeDiscount: doc.totalRevenueBeforeDiscount,
+              totalTicketsSold: doc.totalTicketsSold,
+              totalCommissionEarned: doc.totalCommissionEarned,
+              totalTicketsRewarded: doc.totalTicketsRewarded,
+              lastActivityDate: new Date().toISOString(),
+              rankAchievedDate: new Date().toISOString(),
+            },
+          })
+        } else {
+          // update affiliate user rank
+          let pendingRankUpgrade: AffiliateRank | null = null
+          const totalPoints = (affiliateUserRank.totalPoints || 0) + (doc.totalPoints || 0)
+          const nextRankCanReach = sortedRanks.find((rank) => totalPoints >= rank.minPoints)
+          if (nextRankCanReach && nextRankCanReach.rankName !== affiliateUserRank.currentRank) {
+            pendingRankUpgrade = nextRankCanReach.rankName as AffiliateRank
+          }
+          await req.payload.update({
+            collection: 'affiliate-user-ranks',
+            id: affiliateUserRank.id,
+            data: {
+              pendingRankUpgrade,
+              lastActivityDate: new Date().toISOString(),
+              totalPoints: totalPoints,
+              totalRevenue: (affiliateUserRank.totalRevenue || 0) + (doc.totalRevenue || 0),
+              totalRevenueBeforeTax:
+                (affiliateUserRank.totalRevenueBeforeTax || 0) + (doc.totalRevenueBeforeTax || 0),
+              totalRevenueAfterTax:
+                (affiliateUserRank.totalRevenueAfterTax || 0) + (doc.totalRevenueAfterTax || 0),
+              totalRevenueBeforeDiscount:
+                (affiliateUserRank.totalRevenueBeforeDiscount || 0) +
+                (doc.totalRevenueBeforeDiscount || 0),
+              totalTicketsSold:
+                (affiliateUserRank.totalTicketsSold || 0) + (doc.totalTicketsSold || 0),
+              totalCommissionEarned:
+                (affiliateUserRank.totalCommissionEarned || 0) + (doc.totalCommissionEarned || 0),
+              totalTicketsRewarded:
+                (affiliateUserRank.totalTicketsRewarded || 0) + (doc.totalTicketsRewarded || 0),
             },
           })
         }
+
+        const pointsBefore = affiliateUserRank?.totalPoints || 0
+        const pointsAfter = pointsBefore + (doc.totalPoints || 0)
+        const pointsChange = pointsAfter - pointsBefore
+        // need to write log
+        await req.payload.create({
+          collection: 'affiliate-rank-logs',
+          data: {
+            affiliateUser: affiliateUserId,
+            eventAffiliateRank: doc.eventAffiliateRank,
+            rankContext: 'user',
+            pointsChange,
+            pointsBefore,
+            pointsAfter,
+            rankBefore: affiliateUserRank?.currentRank,
+            actionType: AFFILIATE_ACTION_TYPE_LOG.event_completed.value,
+            occurredAt: new Date().toISOString(),
+            description: `Cập nhật điểm tích lũy, doanh thu, số vé bán được, hoa hồng nhận được, số vé thưởng có thể nhận được từ sự kiện sau khi event đã hoàn thành`,
+          },
+        })
+        // }
       },
     ],
   },

--- a/src/components/Affiliate/AffiliateRankUpgradeNotification.tsx
+++ b/src/components/Affiliate/AffiliateRankUpgradeNotification.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+type EventUpgradeNotification = {
+  type: 'event-rank-upgrade'
+  rank: string
+  eligibleEvents: { eventId: string; oldRank: string }[]
+  timestamp: number
+}
+
+export default function AffiliateRankUpgradeNotification() {
+  const [notifications, setNotifications] = useState<EventUpgradeNotification[]>([])
+  const [confirmedEvents, setConfirmedEvents] = useState<Set<string>>(new Set())
+
+  useEffect(() => {
+    const fetchNotifications = async () => {
+      const res = await fetch(`/api/notify-event-rank-upgrade`)
+      const json = await res.json()
+      if (json.notifications) {
+        setNotifications(json.notifications)
+      }
+    }
+
+    fetchNotifications()
+  }, [])
+
+  const handleConfirm = async (eventId: string, rank: string) => {
+    try {
+      const res = await fetch('/api/confirm-event-rank-upgrade', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ eventIds: [eventId], newRank: rank }),
+      })
+
+      const json = await res.json()
+
+      if (json.success) {
+        setConfirmedEvents((prev) => new Set([...prev, eventId]))
+      } else {
+        alert('Có lỗi xảy ra khi xác nhận.')
+      }
+    } catch (err) {
+      console.error(err)
+      alert('Không thể gửi xác nhận. Vui lòng thử lại.')
+    }
+  }
+
+  if (!notifications.length) return null
+
+  return (
+    <div className="p-4 mb-4 border border-blue-400 bg-blue-100 text-blue-800 rounded">
+      {notifications.map((notif, i) => (
+        <div key={i} className="mb-4">
+          <p className="font-semibold">
+            🎉 Bạn đã được nâng lên hạng <strong>{notif.rank} cho hạng tổng !</strong>
+          </p>
+          <p>Các sự kiện đủ điều kiện nâng cấp:</p>
+          <ul className="list-disc list-inside mt-2 space-y-2">
+            {notif.eligibleEvents.map((e, idx) => (
+              <li key={idx} className="flex justify-between items-center gap-4">
+                <span>
+                  Sự kiện ID: <strong>{e.eventId}</strong> (hạng cũ: {e.oldRank})
+                </span>
+                <button
+                  onClick={() => handleConfirm(e.eventId, notif.rank)}
+                  disabled={confirmedEvents.has(e.eventId)}
+                  className={`px-3 py-1 rounded text-white text-sm ${
+                    confirmedEvents.has(e.eventId)
+                      ? 'bg-gray-400 cursor-not-allowed'
+                      : 'bg-blue-600 hover:bg-blue-700'
+                  }`}
+                >
+                  {confirmedEvents.has(e.eventId) ? 'Đã xác nhận' : 'Xác nhận'}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
- Removed "đã hoàn thành" button in EventAffUserRank collection -> Points are saved directly to AffiliateUserRank collection
- Created afterChange hook to update affiliate user rank when eligible & send event eligible for upgrade to notify-rank-upgrade endpoint
- Created API endpoints to handle notifying and confirming event rank upgrade
- Created sample frontend component for displaying upgrade notification